### PR TITLE
Quicklogic: ABC9 attributes

### DIFF
--- a/techlibs/quicklogic/ap2_cells_sim.v
+++ b/techlibs/quicklogic/ap2_cells_sim.v
@@ -34,6 +34,7 @@ module LUT5 (
   assign O = I0 ? s1[1] : s1[0];
 endmodule
 
+(* abc9_flop, lib_whitebox *)
 module dff (
   output reg Q,
   input D,
@@ -45,6 +46,7 @@ module dff (
   always @(posedge CLK) Q <= D;
 endmodule
 
+(* abc9_box, lib_whitebox *)
 module dffc (
   output reg Q,
   input D,
@@ -61,6 +63,7 @@ module dffc (
     else Q <= D;
 endmodule
 
+(* abc9_box, lib_whitebox *)
 module dffp (
   output reg Q,
   input D,
@@ -77,7 +80,7 @@ module dffp (
     else Q <= D;
 endmodule
 
-(* abc9_flop, lib_whitebox *)
+(* abc9_box, lib_whitebox *)
 module dffpc (
   output reg Q,
   input D,
@@ -97,6 +100,7 @@ module dffpc (
     else Q <= D;
 endmodule
 
+(* abc9_flop, lib_whitebox *)
 module dffe (
   output reg Q,
   input D,
@@ -109,6 +113,7 @@ module dffe (
   always @(posedge CLK) if (EN) Q <= D;
 endmodule
 
+(* abc9_box, lib_whitebox *)
 module dffepc (
   output reg Q,
   input D,
@@ -129,6 +134,7 @@ module dffepc (
     else if (EN) Q <= D;
 endmodule
 
+(* abc9_box, lib_whitebox *)
 module dffsec (
   output reg Q,
   input D,
@@ -146,6 +152,7 @@ module dffsec (
     else if (EN) Q <= D;
 endmodule
 
+(* abc9_box, lib_whitebox *)
 module dffsep (
   output reg Q,
   input D,

--- a/techlibs/quicklogic/ap3_cells_sim.v
+++ b/techlibs/quicklogic/ap3_cells_sim.v
@@ -15,7 +15,7 @@ module LUT4 (
   assign O = I0 ? s1[1] : s1[0];
 endmodule
 
-(* abc9_flop, lib_whitebox *)
+(* abc9_box, lib_whitebox *)
 module FF (
   output reg CQZ,
   input D,


### PR DESCRIPTION
`(* abc9_flop *)` on `dffpc` and `FF` is wrong because an ABC9 flop must be purely synchronous, and these models have asynchronous sets/resets. However, `(* abc9_flop *)` can be added for synchronous flops like `dff[e]` and the asynchronous sets/reset can be modelled as combinational `(* abc9_box *)`es.

No functional change (at the moment).
