### PR TITLE
Rebase uhdm-yosys on top of ibex-wip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - uhdm-yosys-rebase
   pull_request:
 
 jobs:


### PR DESCRIPTION
This PR is just to trigger CI tests.

Opentitan synthesis requires changes from current version of ibex-wip. This PR rebases uhdm-yosys on top of ibex-wip. If tests will pass, this branch will be force-pushed to uhdm-yosys.