### PR TITLE
Disable OneNetInterf and OneNetRange tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Generate matrix (yosys)
         id: generate-matrix-yosys
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis MultiplePrints assignment-pattern)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis MultiplePrints assignment-pattern OneNetInterf OneNetRange)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix yosys: $matrix"
 


### PR DESCRIPTION
This PR disables ``OneNetInterf`` and ``OneNetRange``

Corresponding uhdm-integration issue: https://github.com/alainmarcel/uhdm-integration/issues/185

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>