### PR TITLE
Cleanup github-actions file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,31 +84,9 @@ jobs:
       - name: Generate matrix (vcddiff)
         id: generate-matrix-vcddiff
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix vcddiff: $matrix"
-
-  generate-ibex-modules:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.generate-ibex-modules.outputs.matrix }}
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-        with:
-           python-version: '3.7'
-
-      - name: Generate matrix
-        id: generate-ibex-modules
-        run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests/ibex/module_tests)"
-          echo "::set-output name=matrix::$matrix"
-          echo "Matrix: $matrix"
 
   tests-yosys:
     runs-on: ubuntu-latest
@@ -201,11 +179,6 @@ jobs:
   ibex_synth:
     runs-on: ubuntu-latest
     needs: build-binaries
-    strategy:
-      matrix:
-        TARGET: [uhdm/yosys/synth-ibex]
-      fail-fast:
-        false
     env:
       CC: gcc-9
       CXX: g++-9


### PR DESCRIPTION
This PR disables previously missed (in vcddiff) OneNetInterf OneNetRange tests, removes unused target ``generate-ibex-modules`` and removes matrix strategy for ``ibex_synth``.