### PR TITLE
Streaming operators

### DIFF
--- a/frontends/uhdm/UhdmAst.h
+++ b/frontends/uhdm/UhdmAst.h
@@ -34,7 +34,8 @@ class UhdmAst {
 
 		// Create an AstNode of the specified type with metadata extracted from
 		// the given vpiHandle.
-		AST::AstNode* make_ast_node(AST::AstNodeType type, vpiHandle obj_h);
+		AST::AstNode* make_ast_node(AST::AstNodeType type,
+					    std::vector<AST::AstNode*> children = {});
 
 		// Makes the passed node a cell node of the specified type
 		void make_cell(vpiHandle obj_h, AST::AstNode* node, AST::AstNode* type);
@@ -93,6 +94,7 @@ class UhdmAst {
 		void process_initial();
 		void process_begin();
 		void process_operation();
+		void process_stream_op();
 		void process_list_op();
 		void process_cast_op();
 		void process_inside_op();


### PR DESCRIPTION
Adds support for streaming operators. A streaming operator appears once in OpenTitan:
https://github.com/alainmarcel/Surelog/blob/e1ae84f3ac267760012058b9ec0adc1cd0e46982/third_party/tests/Earlgrey_Verilator_0_1/src/lowrisc_ip_hmac_0.1/rtl/hmac_pkg.sv#L51

This PR also cleans up some of the code (`make_ast_node` was changed which affects a lot of the code in `UhdmAst.cc`, but it's fairly simple).

The implementation may need some adjustments after https://github.com/alainmarcel/Surelog/issues/1067 is fixed.

I added a test to `uhdm-integration` on a separate branch, but I'm not sure how adding new tests works currently. Here it is: https://github.com/alainmarcel/uhdm-integration/blob/stream-op/tests/StreamOp/dut.v