### PR TITLE
Move ibex_multdiv_fast and ibex_wb_stage to uhdm

### DIFF
--- a/frontends/uhdm/UhdmAst.cc
+++ b/frontends/uhdm/UhdmAst.cc
@@ -403,6 +403,7 @@ void UhdmAst::process_port() {
 			}
 			case vpiLogicNet: {
 				current_node->is_logic = true;
+				current_node->is_signed = vpi_get(vpiSigned, actual_h);
 				visit_range(actual_h,
 							[&](AST::AstNode* node) {
 								if (node->type == AST::AST_MULTIRANGE) node->is_packed = true;
@@ -818,6 +819,7 @@ void UhdmAst::process_net() {
 	current_node->is_reg = net_type == vpiReg;
 	current_node->is_output = net_type == vpiOutput;
 	current_node->is_logic = true;
+	current_node->is_signed = vpi_get(vpiSigned, obj_h);
 	visit_range(obj_h,
 				[&](AST::AstNode* node) {
 					current_node->children.push_back(node);
@@ -847,6 +849,7 @@ void UhdmAst::process_array_net() {
 	while (vpiHandle net_h = vpi_scan(itr)) {
 		if (vpi_get(vpiType, net_h) == vpiLogicNet) {
 			current_node->is_logic = true;
+			current_node->is_signed = vpi_get(vpiSigned, net_h);
 			visit_range(net_h,
 						[&](AST::AstNode* node) {
 							current_node->children.push_back(node);

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -16,6 +16,30 @@ index 962d3b559..d6430bc5a 100644
  `else
      // different driver types
      assign (strong0, strong1) inout_io = (oe && drv != DRIVE_00) ? out : 1'bz;
+diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
+index 617bb5162..11ccd8fd2 100644
+--- a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
++++ b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
+@@ -15,7 +15,7 @@
+ `include "prim_assert.sv"
+ 
+ module ibex_multdiv_fast #(
+-    parameter bit SingleCycleMultiply = 0
++    parameter bit SingleCycleMultiply = 1
+   ) (
+     input  logic             clk_i,
+     input  logic             rst_ni,
+@@ -35,8 +35,8 @@ module ibex_multdiv_fast #(
+     output logic [32:0]      alu_operand_a_o,
+     output logic [32:0]      alu_operand_b_o,
+ 
+-    input  logic [33:0]      imd_val_q_i[2],
+-    output logic [33:0]      imd_val_d_o[2],
++    input  logic [1:0][33:0]      imd_val_q_i,
++    output logic [1:0][33:0]      imd_val_d_o,
+     output logic [1:0]       imd_val_we_o,
+ 
+     input  logic             multdiv_ready_id_i,
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
 index 1b48693a0..5ff425c4e 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -53,3 +53,35 @@ index 1b48693a0..5ff425c4e 100644
  ) (
      // Clock and Reset
      input  logic                    clk_i,
+diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
+index ffe380ff4..ddfa1aa22 100644
+--- a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
++++ b/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
+@@ -14,7 +14,7 @@
+ `include "prim_assert.sv"
+ 
+ module ibex_wb_stage #(
+-  parameter bit WritebackStage = 1'b0
++  parameter bit WritebackStage = 1'b1
+ ) (
+   input  logic                     clk_i,
+   input  logic                     rst_ni,
+@@ -51,8 +51,9 @@ module ibex_wb_stage #(
+ 
+   // 0 == RF write from ID
+   // 1 == RF write from LSU
+-  logic [31:0] rf_wdata_wb_mux    [2];
++  logic [1:0][31:0] rf_wdata_wb_mux;
+   logic [1:0]  rf_wdata_wb_mux_we;
++  wb_instr_type_e wb_instr_type_q;
+ 
+   if(WritebackStage) begin : g_writeback_stage
+     logic [31:0]    rf_wdata_wb_q;
+@@ -63,7 +64,6 @@ module ibex_wb_stage #(
+ 
+     logic           wb_valid_q;
+     logic [31:0]    wb_pc_q;
+-    wb_instr_type_e wb_instr_type_q;
+ 
+     logic           wb_valid_d;
+ 

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -83,7 +83,6 @@ ibex_cs_registers.sv \
 ibex_ex_block.sv \
 ibex_id_stage.sv \
 ibex_if_stage.sv \
-ibex_multdiv_fast.sv \
 ibex_prefetch_buffer.sv \
 ibex_wb_stage.sv \
 ibex_dummy_instr.sv \
@@ -243,6 +242,7 @@ ibex_fetch_fifo.sv \
 ibex_multdiv_slow.sv \
 ibex_pmp.sv \
 ibex_load_store_unit.sv \
+ibex_multdiv_fast.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -291,8 +291,8 @@ uhdm/yosys/synth-opentitan: ${UHDM_file} ${SV2V_FILE} | ${VENV_OT}
 		-p "verilog_defines -DPRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx" \
 		-p "verilog_defaults -push" \
 		-p "verilog_defaults -add -defer" \
-		-p "read_uhdm -defer ${UHDM_file}" \
-		-p "read_verilog ${SV2V_FILE}" \
+		-p "read_uhdm -debug -defer ${UHDM_file}" \
+		-p "read_verilog -dump_ast1 ${SV2V_FILE}" \
 		-p "read_verilog -overwrite ${CUSTOM_FILES}" \
 		-p "verilog_defaults -pop" \
 	        -p 'synth_xilinx -iopad -family xc7 -top top_earlgrey_nexysvideo' \

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -84,7 +84,6 @@ ibex_ex_block.sv \
 ibex_id_stage.sv \
 ibex_if_stage.sv \
 ibex_prefetch_buffer.sv \
-ibex_wb_stage.sv \
 ibex_dummy_instr.sv \
 ibex_register_file_ff.sv \
 ibex_core.sv \
@@ -243,6 +242,7 @@ ibex_multdiv_slow.sv \
 ibex_pmp.sv \
 ibex_load_store_unit.sv \
 ibex_multdiv_fast.sv \
+ibex_wb_stage.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \


### PR DESCRIPTION
This PR adds signed attribute (if present in UHDM) to ``array net`` and``logic net``.

This PR also moves ``ibex_multdiv_fast`` and ``ibex_wb_stage`` to uhdm with patch changing unpacked array (that is currently not supported in yosys) to packed array.

Fixes: https://github.com/alainmarcel/uhdm-integration/issues/199
Fixes: https://github.com/alainmarcel/uhdm-integration/issues/212