### PR TITLE
Move ibex_core to uhdm

### DIFF
--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -16,33 +16,62 @@ index 962d3b559..d6430bc5a 100644
  `else
      // different driver types
      assign (strong0, strong1) inout_io = (oe && drv != DRIVE_00) ? out : 1'bz;
+diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+index 61469937f..54e9f7ec1 100644
+--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
++++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+@@ -133,8 +133,8 @@ module ibex_core #(
+   logic [31:0] pc_if;                          // Program counter in IF stage
+   logic [31:0] pc_id;                          // Program counter in ID stage
+   logic [31:0] pc_wb;                          // Program counter in WB stage
+-  logic [33:0] imd_val_d_ex[2];                // Intermediate register for multicycle Ops
+-  logic [33:0] imd_val_q_ex[2];                // Intermediate register for multicycle Ops
++  logic [1:0][33:0] imd_val_d_ex;                // Intermediate register for multicycle Ops
++  logic [1:0][33:0] imd_val_q_ex;                // Intermediate register for multicycle Ops
+   logic [1:0]  imd_val_we_ex;
+ 
+   logic        data_ind_timing;
+@@ -254,7 +254,7 @@ module ibex_core #(
+   logic [31:0] csr_mepc, csr_depc;
+ 
+   // PMP signals
+-  logic [33:0] csr_pmp_addr [PMPNumRegions];
++  logic [PMPNumRegions-1:0][33:0] csr_pmp_addr;
+   pmp_cfg_t    csr_pmp_cfg  [PMPNumRegions];
+   logic        pmp_req_err  [PMP_NUM_CHAN];
+   logic        instr_req_out;
+@@ -931,17 +931,17 @@ module ibex_core #(
+       })
+   `ASSERT_KNOWN_IF(IbexCsrWdataIntKnown, cs_registers_i.csr_wdata_int, csr_op_en)
+ 
++  logic [PMP_NUM_CHAN-1:0][1:0]    pmp_req_type;
++  logic [PMP_NUM_CHAN-1:0][1:0]    pmp_priv_lvl;
++  logic [PMP_NUM_CHAN-1:0][33:0] pmp_req_addr;
+   if (PMPEnable) begin : g_pmp
+-    logic [33:0] pmp_req_addr [PMP_NUM_CHAN];
+-    pmp_req_e    pmp_req_type [PMP_NUM_CHAN];
+-    priv_lvl_e   pmp_priv_lvl [PMP_NUM_CHAN];
+-
+-    assign pmp_req_addr[PMP_I] = {2'b00,instr_addr_o[31:0]};
+-    assign pmp_req_type[PMP_I] = PMP_ACC_EXEC;
+-    assign pmp_priv_lvl[PMP_I] = priv_mode_if;
+-    assign pmp_req_addr[PMP_D] = {2'b00,data_addr_o[31:0]};
+-    assign pmp_req_type[PMP_D] = data_we_o ? PMP_ACC_WRITE : PMP_ACC_READ;
+-    assign pmp_priv_lvl[PMP_D] = priv_mode_lsu;
++
++    assign pmp_req_addr[PMP_D] = {2'b00,instr_addr_o[31:0]};
++    assign pmp_req_type[PMP_D] = PMP_ACC_EXEC;
++    assign pmp_priv_lvl[PMP_D] = priv_mode_if;
++    assign pmp_req_addr[PMP_I] = {2'b00,data_addr_o[31:0]};
++    assign pmp_req_type[PMP_I] = data_we_o ? PMP_ACC_WRITE : PMP_ACC_READ;
++    assign pmp_priv_lvl[PMP_I] = priv_mode_lsu;
+ 
+     ibex_pmp #(
+         .PMPGranularity        ( PMPGranularity ),
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
-index 6e5eaf4dc..9668ae5c5 100644
+index 6e5eaf4dc..63a0dacca 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
 +++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
-@@ -13,17 +13,17 @@
- `include "prim_assert.sv"
- 
- module ibex_cs_registers #(
--    parameter bit          DbgTriggerEn      = 0,
-+    parameter bit          DbgTriggerEn      = 1,
-     parameter bit          DataIndTiming     = 1'b0,
-     parameter bit          DummyInstructions = 1'b0,
-     parameter bit          ICache            = 1'b0,
--    parameter int unsigned MHPMCounterNum    = 10,
-+    parameter int unsigned MHPMCounterNum    = 8,
-     parameter int unsigned MHPMCounterWidth  = 40,
--    parameter bit          PMPEnable         = 0,
-+    parameter bit          PMPEnable         = 1,
-     parameter int unsigned PMPGranularity    = 0,
--    parameter int unsigned PMPNumRegions     = 4,
-+    parameter int unsigned PMPNumRegions     = 16,
-     parameter bit          RV32E             = 0,
--    parameter bit          RV32M             = 0
-+    parameter bit          RV32M             = 1
- ) (
-     // Clock and Reset
-     input  logic                 clk_i,
 @@ -64,7 +64,7 @@ module ibex_cs_registers #(
  
      // PMP
@@ -116,20 +145,9 @@ index 6e5eaf4dc..9668ae5c5 100644
      // Expanded / qualified register read data
      for (genvar i = 0; i < PMP_MAX_REGIONS; i++) begin : g_exp_rd_data
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_ex_block.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_ex_block.sv
-index eccc68e95..c8bf69ebd 100644
+index eccc68e95..06a672e88 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_ex_block.sv
 +++ b/hw/vendor/lowrisc_ibex/rtl/ibex_ex_block.sv
-@@ -11,8 +11,8 @@
- module ibex_ex_block #(
-     parameter bit               RV32M                    = 1,
-     parameter ibex_pkg::rv32b_e RV32B                    = ibex_pkg::RV32BNone,
--    parameter bit               BranchTargetALU          = 0,
--    parameter                   MultiplierImplementation = "fast"
-+    parameter bit               BranchTargetALU          = 1,
-+    parameter                   MultiplierImplementation = "single-cycle"
- ) (
-     input  logic                  clk_i,
-     input  logic                  rst_ni,
 @@ -42,8 +42,8 @@ module ibex_ex_block #(
  
      // intermediate val reg
@@ -193,18 +211,9 @@ index bba4c2af8..a4fbb8da6 100644
    op_a_sel_e   bt_a_mux_sel;
    imm_b_sel_e  bt_b_mux_sel;
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
-index 617bb5162..8a11ff71b 100644
+index 617bb5162..a60816d59 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
 +++ b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
-@@ -15,7 +15,7 @@
- `include "prim_assert.sv"
- 
- module ibex_multdiv_fast #(
--    parameter bit SingleCycleMultiply = 0
-+    parameter bit SingleCycleMultiply = 1
-   ) (
-     input  logic             clk_i,
-     input  logic             rst_ni,
 @@ -35,8 +35,8 @@ module ibex_multdiv_fast #(
      output logic [32:0]      alu_operand_a_o,
      output logic [32:0]      alu_operand_b_o,
@@ -234,32 +243,10 @@ index 617bb5162..8a11ff71b 100644
      logic signed [33:0] mult1_res, mult2_res, mult3_res;
      logic [15:0]        mult1_op_a, mult1_op_b;
      logic [15:0]        mult2_op_a, mult2_op_b;
-diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
-index 1b48693a0..5ff425c4e 100644
---- a/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
-+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
-@@ -9,7 +9,7 @@ module ibex_pmp #(
-     // Number of access channels (e.g. i-side + d-side)
-     parameter int unsigned PMPNumChan     = 2,
-     // Number of implemented regions
--    parameter int unsigned PMPNumRegions  = 4
-+    parameter int unsigned PMPNumRegions  = 16
- ) (
-     // Clock and Reset
-     input  logic                    clk_i,
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
-index ffe380ff4..ddfa1aa22 100644
+index ffe380ff4..07f267017 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
 +++ b/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
-@@ -14,7 +14,7 @@
- `include "prim_assert.sv"
- 
- module ibex_wb_stage #(
--  parameter bit WritebackStage = 1'b0
-+  parameter bit WritebackStage = 1'b1
- ) (
-   input  logic                     clk_i,
-   input  logic                     rst_ni,
 @@ -51,8 +51,9 @@ module ibex_wb_stage #(
  
    // 0 == RF write from ID

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -33,6 +33,9 @@ prim_generic_pad_wrapper.sv \
 prim_generic_ram_1p.sv \
 prim_generic_ram_2p.sv \
 prim_generic_rom.sv \
+prim_clock_gating.sv \
+prim_generic_clock_gating.sv \
+prim_xilinx_clock_gating.sv \
 prim_gf_mult.sv \
 prim_clock_mux2.sv \
 prim_flop.sv \
@@ -41,9 +44,6 @@ prim_pad_wrapper.sv \
 prim_ram_1p.sv \
 prim_ram_2p.sv \
 prim_rom.sv \
-prim_clock_gating.sv \
-prim_generic_clock_gating.sv \
-prim_xilinx_clock_gating.sv \
 alert_handler_reg_top.sv \
 padctrl_reg_top.sv \
 pinmux_reg_top.sv \
@@ -80,7 +80,6 @@ prim_ram_1p_adv.sv \
 prim_ram_2p_async_adv.sv \
 prim_rom_adv.sv \
 ibex_dummy_instr.sv \
-ibex_core.sv \
 usb_fs_nb_in_pe.sv \
 usb_fs_nb_out_pe.sv \
 usb_fs_nb_pe.sv \
@@ -244,9 +243,7 @@ ibex_if_stage.sv \
 ibex_id_stage.sv \
 ibex_ex_block.sv \
 ibex_cs_registers.sv \
-prim_clock_gating.sv \
-prim_generic_clock_gating.sv \
-prim_xilinx_clock_gating.sv \
+ibex_core.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -285,6 +282,21 @@ ${UHDM_file}: ${SV2V_FILE}
 			-DSYNTHESIS \
 			-DPRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric \
 			-DBootRomInitFile=boot_rom_fpga_nexysvideo.32.vmem \
+			-PPMPEnable=1 \
+			-PPMPGranularity=0 \
+			-PPMPNumRegions=16 \
+			-PMHPMCounterNum=8 \
+			-PMHPMCounterWidth=40 \
+			-PRV32E=0 \
+			-PRV32M=1 \
+			-PBranchTargetALU=1 \
+			-PWritebackStage=1 \
+			-PMultiplierImplementation="single-cycle" \
+			-PICache=0 \
+			-PICacheECC=0 \
+			-PDbgTriggerEn=1 \
+			-PSecureIbex=0 \
+			-top ibex_core \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -23,10 +23,8 @@ EARLGRAY_PKG_SOURCES = \
                 sed 's@^..@${EARLGRAY_BUILD}@')
 
 SV2V_FILES = \
-prim_generic_clock_gating.sv \
 prim_generic_flop.sv \
 prim_generic_flop_2sync.sv \
-prim_xilinx_clock_gating.sv \
 prim_xilinx_clock_mux2.sv \
 prim_xilinx_pad_wrapper.sv \
 prim_diff_decode.sv \
@@ -36,7 +34,6 @@ prim_generic_ram_1p.sv \
 prim_generic_ram_2p.sv \
 prim_generic_rom.sv \
 prim_gf_mult.sv \
-prim_clock_gating.sv \
 prim_clock_mux2.sv \
 prim_flop.sv \
 prim_flop_2sync.sv \
@@ -44,6 +41,9 @@ prim_pad_wrapper.sv \
 prim_ram_1p.sv \
 prim_ram_2p.sv \
 prim_rom.sv \
+prim_clock_gating.sv \
+prim_generic_clock_gating.sv \
+prim_xilinx_clock_gating.sv \
 alert_handler_reg_top.sv \
 padctrl_reg_top.sv \
 pinmux_reg_top.sv \
@@ -226,6 +226,7 @@ SV2V_FILES_FULL = \
 
 UHDM_FILES = \
 ibex_pkg.sv \
+prim_pkg.sv \
 ibex_compressed_decoder.sv \
 ibex_alu.sv \
 ibex_controller.sv \
@@ -243,6 +244,9 @@ ibex_if_stage.sv \
 ibex_id_stage.sv \
 ibex_ex_block.sv \
 ibex_cs_registers.sv \
+prim_clock_gating.sv \
+prim_generic_clock_gating.sv \
+prim_xilinx_clock_gating.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -279,6 +283,8 @@ ${UHDM_file}: ${SV2V_FILE}
 	(cd ${EARLGRAY_BUILD} && \
 		${root_dir}/../image/bin/surelog -parse -sverilog \
 			-DSYNTHESIS \
+			-DPRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric \
+			-DBootRomInitFile=boot_rom_fpga_nexysvideo.32.vmem \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})
@@ -288,7 +294,7 @@ uhdm/yosys/synth-opentitan: ${UHDM_file} ${SV2V_FILE} | ${VENV_OT}
 	(cd ${root_dir}/build && \
 	${root_dir}/../image/bin/yosys \
 		-p "verilog_defines -DBootRomInitFile=boot_rom_fpga_nexysvideo.32.vmem" \
-		-p "verilog_defines -DPRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx" \
+		-p "verilog_defines -DPRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric" \
 		-p "verilog_defaults -push" \
 		-p "verilog_defaults -add -defer" \
 		-p "read_uhdm -debug ${UHDM_file}" \


### PR DESCRIPTION
Moves ibex_core to uhdm, but moves prim_clock_gating files back to sv2v. prim_clock_gating module is also used in ``clkmgr`` and it needs to be moved with ``clkmgr`` module.

Fixes: https://github.com/alainmarcel/uhdm-integration/issues/216