### PR TITLE
Update Surelog

### DIFF
--- a/uhdm-tests/ibex/top_artya7_core.patch
+++ b/uhdm-tests/ibex/top_artya7_core.patch
@@ -18,13 +18,13 @@ index 811fb93..3a45048 100644
 +        synth: "yosys"
 +        yosys_synth_options: ['-iopad', '-family xc7', '-run :check', "frontend=surelog"]
 +        yosys_read_options: ['-noassert']
-+        surelog_options: ['-verilator']
++        surelog_options: ['--disable-feature=parametersubstitution']
 +        library_files: ""
 +      yosys:
 +        arch: "xilinx"
 +        yosys_synth_options: ['-iopad', '-family xc7', '-run :check', "frontend=surelog"]
 +        yosys_read_options: ['-noassert']
-+        surelog_options: ['-verilator']
++        surelog_options: ['--disable-feature=parametersubstitution']
 +        library_files: ""
 +      symbiflow:
 +        package: "csg324-1"
@@ -32,5 +32,5 @@ index 811fb93..3a45048 100644
 +        pnr: "vtr"
 +        vendor: "xilinx"
 +        yosys_frontend: "uhdm"
-+        surelog_options: ['-verilator']
++        surelog_options: ['--disable-feature=parametersubstitution']
 +        library_files: []


### PR DESCRIPTION
This PR bumps Surelog and updates ibex patch to match new name of parameter that disables parameter substitution.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>