### PR TITLE
Move rstmgr_por, prim_flop_2sync and prim_generic_flop_2sync to uhdm

### DIFF
--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -198,7 +198,6 @@ rv_plic_reg_top.sv \
 rv_plic.sv \
 rstmgr_reg_top.sv \
 rstmgr_ctrl.sv \
-rstmgr_por.sv \
 rstmgr_info.sv \
 rstmgr.sv \
 prim_alert_pkg.sv \
@@ -247,6 +246,9 @@ ibex_ex_block.sv \
 ibex_cs_registers.sv \
 ibex_core.sv \
 tlul_adapter_host.sv \
+prim_generic_flop_2sync.sv \
+prim_flop_2sync.sv \
+rstmgr_por.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -302,6 +304,7 @@ ${UHDM_file}: ${SV2V_FILE}
 			-PSecureIbex=0 \
 			-top ibex_core \
 			-top tlul_adapter_host \
+			-top rstmgr_por \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})


### PR DESCRIPTION
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>