### PR TITLE
Move rstmgr and rv_core_ibex to uhdm

### DIFF
--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -16,6 +16,47 @@ index 962d3b559..d6430bc5a 100644
  `else
      // different driver types
      assign (strong0, strong1) inout_io = (oe && drv != DRIVE_00) ? out : 1'bz;
+diff --git a/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv b/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+index 4a6a9d709..3c755c66f 100644
+--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
++++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+@@ -116,7 +116,7 @@ package pwrmgr_reg_pkg;
+     pwrmgr_reg2hw_intr_test_reg_t intr_test; // [47:46]
+     pwrmgr_reg2hw_control_reg_t control; // [45:42]
+     pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [41:40]
+-    pwrmgr_reg2hw_wakeup_en_mreg_t [15:0] wakeup_en; // [39:24]
++    logic [15:0] wakeup_en; // [39:24]
+     pwrmgr_reg2hw_reset_en_reg_t reset_en; // [23:22]
+     pwrmgr_reg2hw_wake_info_capture_dis_reg_t wake_info_capture_dis; // [21:21]
+     pwrmgr_reg2hw_wake_info_reg_t wake_info; // [20:0]
+diff --git a/hw/ip/tlul/rtl/tlul_fifo_sync.sv b/hw/ip/tlul/rtl/tlul_fifo_sync.sv
+index 59fe3ffd4..071a30b94 100644
+--- a/hw/ip/tlul/rtl/tlul_fifo_sync.sv
++++ b/hw/ip/tlul/rtl/tlul_fifo_sync.sv
+@@ -7,8 +7,8 @@
+ // and one for the response side.
+ 
+ module tlul_fifo_sync #(
+-  parameter int unsigned ReqPass  = 1'b1,
+-  parameter int unsigned RspPass  = 1'b1,
++  parameter int unsigned ReqPass  = 0,
++  parameter int unsigned RspPass  = 0,
+   parameter int unsigned ReqDepth = 2,
+   parameter int unsigned RspDepth = 2,
+   parameter int unsigned SpareReqW = 1,
+diff --git a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
+index f771dd35a..88c1de4a4 100644
+--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
++++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
+@@ -116,7 +116,7 @@ package pwrmgr_reg_pkg;
+     pwrmgr_reg2hw_intr_test_reg_t intr_test; // [17:16]
+     pwrmgr_reg2hw_control_reg_t control; // [15:12]
+     pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [11:10]
+-    pwrmgr_reg2hw_wakeup_en_mreg_t [0:0] wakeup_en; // [9:9]
++    logic [0:0] wakeup_en; // [9:9]
+     pwrmgr_reg2hw_reset_en_reg_t reset_en; // [8:7]
+     pwrmgr_reg2hw_wake_info_capture_dis_reg_t wake_info_capture_dis; // [6:6]
+     pwrmgr_reg2hw_wake_info_reg_t wake_info; // [5:0]
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
 index 61469937f..12f0a2bcd 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
@@ -204,6 +245,21 @@ index 617bb5162..e1890da38 100644
      output logic [1:0]       imd_val_we_o,
  
      input  logic             multdiv_ready_id_i,
+diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
+index 1b48693a0..b51c400ef 100644
+--- a/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
++++ b/hw/vendor/lowrisc_ibex/rtl/ibex_pmp.sv
+@@ -30,8 +30,8 @@ module ibex_pmp #(
+   import ibex_pkg::*;
+ 
+   // Access Checking Signals
+-  logic [33:0]                                region_start_addr [PMPNumRegions];
+-  logic [33:PMPGranularity+2]                 region_addr_mask  [PMPNumRegions];
++  logic [PMPNumRegions-1:0][33:0]                                region_start_addr;
++  logic [PMPNumRegions-1:0][33:PMPGranularity+2]                 region_addr_mask;
+   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_gt;
+   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_lt;
+   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_eq;
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
 index ffe380ff4..6f518796f 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -79,6 +79,7 @@ prim_generic_flash.sv \
 prim_ram_1p_adv.sv \
 prim_ram_2p_async_adv.sv \
 prim_rom_adv.sv \
+tlul_adapter_host.sv \
 ibex_dummy_instr.sv \
 usb_fs_nb_in_pe.sv \
 usb_fs_nb_out_pe.sv \
@@ -162,7 +163,6 @@ padring.sv \
 padctrl.sv \
 pinmux_wkup.sv \
 pinmux.sv \
-rv_core_ibex.sv \
 rv_dm.sv \
 rv_plic_gateway.sv \
 rv_plic_target.sv \
@@ -261,6 +261,9 @@ prim_generic_clock_mux2.sv \
 rstmgr_ctrl.sv \
 rstmgr_info.sv \
 rstmgr.sv \
+prim_fifo_sync.sv \
+tlul_fifo_sync.sv \
+rv_core_ibex.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -316,9 +319,8 @@ ${UHDM_file}: ${SV2V_FILE}
 			-PSecureIbex=0 \
 			-PWidth=2 \
 			-PResetValue=0 \
-			-PReqPass=0 \
-			-PRspPass=0 \
-			-top ibex_core \
+			-PPipeLine=1 \
+			-top rv_core_ibex \
 			-top tlul_adapter_host \
 			-top rstmgr_por \
 			-top rstmgr_reg_top \

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -196,9 +196,6 @@ clkmgr_reg_top.sv \
 clkmgr.sv \
 rv_plic_reg_top.sv \
 rv_plic.sv \
-rstmgr_ctrl.sv \
-rstmgr_info.sv \
-rstmgr.sv \
 prim_alert_pkg.sv \
 prim_secded_28_22_dec.sv \
 prim_secded_28_22_enc.sv \
@@ -227,6 +224,9 @@ top_pkg.sv \
 tlul_pkg.sv \
 prim_util_pkg.sv \
 rstmgr_reg_pkg.sv \
+pwrmgr_reg_pkg.sv \
+pwrmgr_pkg.sv \
+rstmgr_pkg.sv \
 ibex_compressed_decoder.sv \
 ibex_alu.sv \
 ibex_controller.sv \
@@ -246,6 +246,7 @@ ibex_ex_block.sv \
 ibex_cs_registers.sv \
 ibex_core.sv \
 tlul_adapter_host.sv \
+tlul_err.sv \
 prim_generic_flop_2sync.sv \
 prim_flop_2sync.sv \
 rstmgr_por.sv \
@@ -255,6 +256,11 @@ prim_subreg_ext.sv \
 rstmgr_reg_top.sv \
 prim_flop.sv \
 prim_generic_flop.sv \
+prim_clock_mux2.sv \
+prim_generic_clock_mux2.sv \
+rstmgr_ctrl.sv \
+rstmgr_info.sv \
+rstmgr.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -310,11 +316,14 @@ ${UHDM_file}: ${SV2V_FILE}
 			-PSecureIbex=0 \
 			-PWidth=2 \
 			-PResetValue=0 \
+			-PReqPass=0 \
+			-PRspPass=0 \
 			-top ibex_core \
 			-top tlul_adapter_host \
 			-top rstmgr_por \
 			-top rstmgr_reg_top \
 			-top prim_flop_2sync \
+			-top rstmgr \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})


### PR DESCRIPTION
This PR moves rstmgr and rv_core_ibex to uhdm.

I have created separate issue to add proper support for arrays of typedefs in array: https://github.com/alainmarcel/uhdm-integration/issues/228, for now I patched ``pwrmgr_reg_pkg.sv`` file to use explicite type.

Fixes: https://github.com/alainmarcel/uhdm-integration/issues/226
Fixes: https://github.com/alainmarcel/uhdm-integration/issues/224

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>