### PR TITLE
Bump udhm-integration: Add implicit sensitivity list tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Generate matrix (yosys)
         id: generate-matrix-yosys
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis MultiplePrints assignment-pattern OneNetInterf OneNetRange opentitan)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis MultiplePrints assignment-pattern OneNetInterf OneNetRange opentitan DpiChandle RealValue PutC)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix yosys: $matrix"
 
@@ -84,7 +84,7 @@ jobs:
       - name: Generate matrix (vcddiff)
         id: generate-matrix-vcddiff
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange opentitan)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange opentitan DpiChandle RealValue PutC)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix vcddiff: $matrix"
 


### PR DESCRIPTION
This also adds some other uhdm-integration commits to make it equal with Verilator. Most probably it will fail on RealValue and other recently added tests (same as in: https://github.com/antmicro/yosys/pull/173)

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>