### PR TITLE
sv-tests: fix some segmentation faults in sv-test

### DIFF
--- a/frontends/uhdm/UhdmAst.cc
+++ b/frontends/uhdm/UhdmAst.cc
@@ -1037,7 +1037,13 @@ void UhdmAst::process_always() {
 		obj_h,
 		[&](AST::AstNode* node) {
 			if (node) {
-				current_node->children.push_back(node);
+				AST::AstNode* block = nullptr;
+				if (node->type != AST::AST_BLOCK) {
+					block = new AST::AstNode(AST::AST_BLOCK, node);
+				} else {
+					block = node;
+				}
+				current_node->children.push_back(block);
 			}
 		});
 	switch (vpi_get(vpiAlwaysType, obj_h)) {


### PR DESCRIPTION
This PR fixes: 

-  ``6.19.4--enum_numerical_expr.sv``
-  ``6.19.4--enum_numerical_expr_cast.sv``
- ``enum_type_checking.sv``

and some more segmentation faults in sv-tests.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>