### PR TITLE
Add basic real value support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Generate matrix (yosys)
         id: generate-matrix-yosys
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis MultiplePrints assignment-pattern OneNetInterf OneNetRange opentitan DpiChandle RealValue PutC)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis MultiplePrints assignment-pattern OneNetInterf OneNetRange opentitan DpiChandle PutC)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix yosys: $matrix"
 
@@ -84,7 +84,7 @@ jobs:
       - name: Generate matrix (vcddiff)
         id: generate-matrix-vcddiff
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange opentitan DpiChandle RealValue PutC)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange opentitan DpiChandle PutC)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix vcddiff: $matrix"
 

--- a/frontends/uhdm/UhdmAst.cc
+++ b/frontends/uhdm/UhdmAst.cc
@@ -894,6 +894,19 @@ void UhdmAst::process_int_var() {
 	visit_default_expr(obj_h);
 }
 
+void UhdmAst::process_real_var() {
+	auto module_node = find_ancestor({AST::AST_MODULE});
+	auto wire_node = make_ast_node(AST::AST_WIRE);
+	auto left_const = AST::AstNode::mkconst_int(63, true);
+	auto right_const = AST::AstNode::mkconst_int(0, true);
+	auto range = new AST::AstNode(AST::AST_RANGE, left_const, right_const);
+	wire_node->children.push_back(range);
+	wire_node->is_signed = true;
+	module_node->children.push_back(wire_node);
+	current_node = make_ast_node(AST::AST_IDENTIFIER);
+	visit_default_expr(obj_h);
+}
+
 void UhdmAst::process_array_var() {
 	current_node = make_ast_node(AST::AST_WIRE);
 	vpiHandle itr = vpi_iterate(vpi_get(vpiType, obj_h) == vpiArrayVar ?
@@ -2115,6 +2128,7 @@ AST::AstNode* UhdmAst::process_object(vpiHandle obj_handle) {
 		case vpiStructVar:
 		case vpiStructNet: process_custom_var(); break;
 		case vpiIntVar: process_int_var(); break;
+		case vpiRealVar: process_real_var(); break;
 		case vpiPackedArrayVar:
 		case vpiArrayVar: process_array_var(); break;
 		case vpiParamAssign: process_param_assign(); break;

--- a/frontends/uhdm/UhdmAst.h
+++ b/frontends/uhdm/UhdmAst.h
@@ -79,6 +79,7 @@ class UhdmAst {
 		void process_enum_const();
 		void process_custom_var();
 		void process_int_var();
+		void process_real_var();
 		void process_array_var();
 		void process_param_assign();
 		void process_cont_assign();


### PR DESCRIPTION
This adds minimal support for real values in a way that prevents total failure when real values are used. Yosys has no support for real value arithmetic at the moment and its default behavior is to round the values to the nearest integer. Note that `RealValue` test will pass but the generated results are not checked. For this test case Yosys generates wrong results due to mentioned rounding to the nearest integer.