### PR TITLE
Revert sv2v changes from tlul_socket_m1 modules

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2106,6 +2106,9 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 				look_str = str;
 				sname = str.substr(0, str.rfind("."));
 			}
+			if (current_scope.count(sname) > 0) {
+				while(current_scope[sname]->simplify(true, false, false, 1, -1, false, false)) { }
+			}
 			if (current_scope.count(look_str) > 0) {
 				auto item_node = current_scope[look_str];
 				if (item_node->type == AST_STRUCT_ITEM || item_node->type == AST_STRUCT) {

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1399,12 +1399,14 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 				// replace with wire representing the packed structure
 				newNode = make_packed_struct(template_node, str);
 				if (children.size() == 2 && children[1]->type == AST_RANGE && port_id == 0 && type == AST_WIRE) {
-					newNode->attributes[ID::wiretype] = mkconst_int(newNode->children[0]->range_left + 1, false, 32);
+					newNode->attributes[ID::wiretype] = new AstNode(AST_CONSTANT);
+					newNode->attributes[ID::wiretype]->children.push_back(newNode->children[0]->clone()); // save original (size of struct) size
  					int s = std::abs(int(children[1]->children[0]->integer - children[1]->children[1]->integer)) + 1;
  					newNode->children[0]->range_left = (newNode->children[0]->range_left + 1) * s;
  					newNode->children[0]->children[0]->integer = (newNode->children[0]->children[0]->integer + 1) * s;
  					newNode->children[0]->range_left -= 1;
  					newNode->children[0]->children[0]->integer -= 1;
+					newNode->attributes[ID::wiretype]->children.push_back(children[1]->clone()); // save unpacked size
 				} else if(children.size() == 2 && children[1]->type == AST_RANGE) {
 					newNode->children.push_back(children[1]->clone());
 				}
@@ -2125,16 +2127,18 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 				while(current_scope[str]->simplify(true, false, false, 1, -1, false, false)) { }
 				if (current_scope[str]->attributes.count(ID::wiretype) && current_scope[str]->attributes[ID::wiretype]->str == "") {
 					auto wiretype = current_scope[str]->attributes[ID::wiretype];
+					auto *curr_range = children[0]->children[0];
 					int struct_size = 0;
+					int struct_mult = curr_range->integer;
 					if (wiretype->children.size() > 0) {
 						struct_size = wiretype->children[0]->range_left + 1;
+						if(wiretype->children[1]->range_swapped) {
+							struct_mult = wiretype->children[1]->range_left - struct_mult;
+						}
 					} else {
 						struct_size = wiretype->integer;
 					}
-					auto *curr_range = children[0]->children[0];
-					int range_left = curr_range->integer + 1;
-					int range_right = curr_range->integer;
-					auto *range = make_range((range_left * struct_size) - 1, range_right * struct_size);
+					auto *range = make_range((struct_size * (struct_mult + 1)) - 1, struct_size * struct_mult);
 					delete children[0];
 					children[0] = range;
 					basic_prep = true;

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <algorithm>
+#include <limits>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -2234,10 +2234,10 @@ index 59fe3ffd4..071a30b94 100644
    parameter int unsigned SpareReqW = 1,
 diff --git a/hw/ip/tlul/rtl/tlul_socket_m1_n2.sv b/hw/ip/tlul/rtl/tlul_socket_m1_n2.sv
 new file mode 100644
-index 000000000..683066c27
+index 000000000..91089db3a
 --- /dev/null
 +++ b/hw/ip/tlul/rtl/tlul_socket_m1_n2.sv
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,256 @@
 +// Copyright lowRISC contributors.
 +// Licensed under the Apache License, Version 2.0, see LICENSE for details.
 +// SPDX-License-Identifier: Apache-2.0
@@ -2273,162 +2273,226 @@ index 000000000..683066c27
 +  parameter bit [3:0]     DReqDepth = 4'h2,
 +  parameter bit [3:0]     DRspDepth = 4'h2
 +) (
-+	input clk_i,
-+	input rst_ni,
-+	input wire [(0 >= (M - 1) ? ((2 - M) * 102) + (((M - 1) * 102) - 1) : (M * 102) - 1):(0 >= (M - 1) ? (M - 1) * 102 : 0)] tl_h_i,
-+	output wire [(0 >= (M - 1) ? ((2 - M) * 68) + (((M - 1) * 68) - 1) : (M * 68) - 1):(0 >= (M - 1) ? (M - 1) * 68 : 0)] tl_h_o,
-+	output wire [101:0] tl_d_o,
-+	input wire [67:0] tl_d_i
++  input                     clk_i,
++  input                     rst_ni,
++
++  input  tlul_pkg::tl_h2d_t tl_h_i [M],
++  output tlul_pkg::tl_d2h_t tl_h_o [M],
++
++  output tlul_pkg::tl_h2d_t tl_d_o,
++  input  tlul_pkg::tl_d2h_t tl_d_i
 +);
-+	localparam signed [31:0] top_pkg_TL_AIW = 8;
-+	localparam signed [31:0] top_pkg_TL_AW = 32;
-+	localparam signed [31:0] top_pkg_TL_DW = 32;
-+	localparam signed [31:0] top_pkg_TL_DBW = 4;
-+	localparam signed [31:0] top_pkg_TL_SZW = 2;
-+	localparam signed [31:0] top_pkg_TL_DIW = 1;
-+	localparam signed [31:0] top_pkg_TL_DUW = 16;
-+	localparam [31:0] IDW = top_pkg_TL_AIW;
-+	localparam [31:0] STIDW = $clog2(M);
-+	wire [(0 >= (M - 1) ? ((2 - M) * 102) + (((M - 1) * 102) - 1) : (M * 102) - 1):(0 >= (M - 1) ? (M - 1) * 102 : 0)] hreq_fifo_o;
-+	wire [67:0] hrsp_fifo_i [0:M - 1];
-+	wire [M - 1:0] hrequest;
-+	wire [M - 1:0] hgrant;
-+	wire [101:0] dreq_fifo_i;
-+	wire [67:0] drsp_fifo_o;
-+	wire arb_valid;
-+	wire arb_ready;
-+	wire [101:0] arb_data;
-+	generate
-+		genvar i;
-+		for (i = 0; i < M; i = i + 1) begin : gen_host_fifo
-+			wire [101:0] hreq_fifo_i;
-+			wire [STIDW - 1:0] reqid_sub;
-+			wire [7:0] shifted_id;
-+			assign reqid_sub = i;
-+			assign shifted_id = {tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 85+:IDW - STIDW], reqid_sub};
-+			wire [7:IDW - STIDW] unused_tl_h_source;
-+			assign unused_tl_h_source = tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 92-:STIDW];
-+			assign hreq_fifo_i = {tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 101],
-+			                      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 100:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 100-3+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 97:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 97-3+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 94:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 94-2+1],
-+					      shifted_id,
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 84:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 84-32+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 52:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 52-4+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 48:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 48-top_pkg_TL_DW+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 16:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 16-16+1],
-+					      tl_h_i[(0 >= (M - 1) ? i : (M - 1) - i) * 102]};
-+			tlul_fifo_sync #(
-+				.ReqPass(HReqPass[i]),
-+				.RspPass(HRspPass[i]),
-+				.ReqDepth(HReqDepth[i * 4+:4]),
-+				.RspDepth(HRspDepth[i * 4+:4]),
-+				.SpareReqW(1)
-+			) u_hostfifo(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.tl_h_i(hreq_fifo_i),
-+				.tl_h_o(tl_h_o[(0 >= (M - 1) ? i : (M - 1) - i) * 68+:68]),
-+				.tl_d_o(hreq_fifo_o[(0 >= (M - 1) ? i : (M - 1) - i) * 102+:102]),
-+				.tl_d_i(hrsp_fifo_i[i]),
-+				.spare_req_i(1'b0),
-+				.spare_req_o(),
-+				.spare_rsp_i(1'b0),
-+				.spare_rsp_o()
-+			);
-+		end
-+	endgenerate
-+	tlul_fifo_sync #(
-+		.ReqPass(DReqPass),
-+		.RspPass(DRspPass),
-+		.ReqDepth(DReqDepth),
-+		.RspDepth(DRspDepth),
-+		.SpareReqW(1)
-+	) u_devicefifo(
-+		.clk_i(clk_i),
-+		.rst_ni(rst_ni),
-+		.tl_h_i(dreq_fifo_i),
-+		.tl_h_o(drsp_fifo_o),
-+		.tl_d_o(tl_d_o),
-+		.tl_d_i(tl_d_i),
-+		.spare_req_i(1'b0),
-+		.spare_req_o(),
-+		.spare_rsp_i(1'b0),
-+		.spare_rsp_o()
-+	);
-+	generate
-+		for (i = 0; i < M; i = i + 1) begin : gen_arbreqgnt
-+			assign hrequest[i] = hreq_fifo_o[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 101];
-+		end
-+	endgenerate
-+	assign arb_ready = drsp_fifo_o[0];
-+	localparam tlul_pkg_ArbiterImpl = "PPC";
-+	generate
-+		if (tlul_pkg_ArbiterImpl == "PPC") begin : gen_arb_ppc
-+			prim_arbiter_ppc_surelog #(
-+				.N(M),
-+				.DW(102)
-+			) u_reqarb(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.req_i(hrequest),
-+				.data_i(hreq_fifo_o),
-+				.gnt_o(hgrant),
-+				.idx_o(),
-+				.valid_o(arb_valid),
-+				.data_o(arb_data),
-+				.ready_i(arb_ready)
-+			);
-+		end
-+		else if (tlul_pkg_ArbiterImpl == "BINTREE") begin : gen_tree_arb
-+			prim_arbiter_tree #(
-+				.N(M),
-+				.DW(102)
-+			) u_reqarb(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.req_i(hrequest),
-+				.data_i(hreq_fifo_o),
-+				.gnt_o(hgrant),
-+				.idx_o(),
-+				.valid_o(arb_valid),
-+				.data_o(arb_data),
-+				.ready_i(arb_ready)
-+			);
-+		end
-+	endgenerate
-+	wire [M - 1:0] hfifo_rspvalid;
-+	wire [M - 1:0] dfifo_rspready;
-+	wire [7:0] hfifo_rspid;
-+	wire dfifo_rspready_merged;
-+	assign dfifo_rspready_merged = |dfifo_rspready;
-+	assign dreq_fifo_i = {arb_valid,
-+	                      arb_data[100:100-3+1],
-+			      arb_data[97:97-3+1],
-+			      arb_data[94:94-2+1],
-+			      arb_data[92:92-8+1],
-+			      arb_data[84:84-32+1],
-+			      arb_data[52:52-4+1],
-+			      arb_data[48:48-top_pkg_TL_DW+1],
-+			      arb_data[16:16-16+1],
-+			      dfifo_rspready_merged};
-+	assign hfifo_rspid = {{STIDW {1'b0}}, drsp_fifo_o[58:51 + STIDW]};
-+	generate
-+		for (i = 0; i < M; i = i + 1) begin : gen_idrouting
-+			assign hfifo_rspvalid[i] = drsp_fifo_o[67] & (drsp_fifo_o[51+:STIDW] == i);
-+			assign dfifo_rspready[i] = (hreq_fifo_o[(0 >= (M - 1) ? i : (M - 1) - i) * 102] & (drsp_fifo_o[51+:STIDW] == i)) & drsp_fifo_o[67];
-+			assign hrsp_fifo_i[i] = {hfifo_rspvalid[i],
-+			                         drsp_fifo_o[66:66-3+1],
-+						 drsp_fifo_o[63:63-3+1],
-+						 drsp_fifo_o[60:60-2+1],
-+						 hfifo_rspid,
-+						 drsp_fifo_o[50:50-1+1],
-+						 drsp_fifo_o[49:49-32+1],
-+						 drsp_fifo_o[17:17-top_pkg_TL_DUW+1],
-+						 drsp_fifo_o[1],
-+						 hgrant[i]};
-+		end
-+	endgenerate
++
++  `ASSERT_INIT(maxM, M < 16)
++
++
++  // Signals
++  //
++  //  tl_h_i/o[0] |  tl_h_i/o[1] | ... |  tl_h_i/o[M-1]
++  //      |              |                    |
++  // u_hostfifo[0]  u_hostfifo[1]        u_hostfifo[M-1]
++  //      |              |                    |
++  //       hreq_fifo_o(i) / hrsp_fifo_i(i)
++  //     ---------------------------------------
++  //     |       request/grant/req_data        |
++  //     |                                     |
++  //     |           PRIM_ARBITER              |
++  //     |                                     |
++  //     |  arb_valid / arb_ready / arb_data   |
++  //     ---------------------------------------
++  //                     |
++  //                dreq_fifo_i / drsp_fifo_o
++  //                     |
++  //                u_devicefifo
++  //                     |
++  //                  tl_d_o/i
++  //
++  // Required ID width to distinguish between host ports
++  //  Used in response steering
++  localparam int unsigned IDW   = top_pkg::TL_AIW;
++  localparam int unsigned STIDW = $clog2(M);
++
++  tlul_pkg::tl_h2d_t hreq_fifo_o [M];
++  tlul_pkg::tl_d2h_t hrsp_fifo_i [M];
++
++  logic [M-1:0] hrequest;
++  logic [M-1:0] hgrant;
++
++  tlul_pkg::tl_h2d_t dreq_fifo_i;
++  tlul_pkg::tl_d2h_t drsp_fifo_o;
++
++  logic arb_valid;
++  logic arb_ready;
++  tlul_pkg::tl_h2d_t arb_data;
++
++  // Host Req/Rsp FIFO
++  for (genvar i = 0 ; i < M ; i++) begin : gen_host_fifo
++    tlul_pkg::tl_h2d_t hreq_fifo_i;
++
++    // ID Shifting
++    logic [STIDW-1:0] reqid_sub;
++    logic [IDW-1:0] shifted_id;
++    logic [7:0] tmp;
++    assign tmp = tl_h_i[i].a_source;
++    assign reqid_sub = i;   // can cause conversion error?
++    assign shifted_id = {
++      tmp[0+:(IDW-STIDW)],
++      reqid_sub
++    };
++
++  `ASSERT(idInRange, tl_h_i[i].a_valid |-> tl_h_i[i].a_source[IDW-1 -:STIDW] == '0)
++
++    // assign not connected bits to nc_* signal to make lint happy
++    logic [IDW-1 : IDW-STIDW] unused_tl_h_source;
++    assign unused_tl_h_source = tmp[IDW-1 -: STIDW];
++
++    // Put shifted ID
++    assign hreq_fifo_i.a_valid = tl_h_i[i].a_valid;
++    assign hreq_fifo_i.a_opcode = tl_h_i[i].a_opcode;
++    assign hreq_fifo_i.a_param = tl_h_i[i].a_param;
++    assign hreq_fifo_i.a_size = tl_h_i[i].a_size;
++    assign hreq_fifo_i.a_source = shifted_id;
++    assign hreq_fifo_i.a_address = tl_h_i[i].a_address;
++    assign hreq_fifo_i.a_mask = tl_h_i[i].a_mask;
++    assign hreq_fifo_i.a_data = tl_h_i[i].a_data;
++    assign hreq_fifo_i.a_user = tl_h_i[i].a_user;
++    assign hreq_fifo_i.d_ready = tl_h_i[i].d_ready;
++
++    tlul_fifo_sync #(
++      .ReqPass    (HReqPass[i]),
++      .RspPass    (HRspPass[i]),
++      .ReqDepth   (HReqDepth[i*4+:4]),
++      .RspDepth   (HRspDepth[i*4+:4]),
++      .SpareReqW  (1)
++    ) u_hostfifo (
++      .clk_i,
++      .rst_ni,
++      .tl_h_i      (hreq_fifo_i),
++      .tl_h_o      (tl_h_o[i]),
++      .tl_d_o      (hreq_fifo_o[i]),
++      .tl_d_i      (hrsp_fifo_i[i]),
++      .spare_req_i (1'b0),
++      .spare_req_o (),
++      .spare_rsp_i (1'b0),
++      .spare_rsp_o ()
++    );
++  end
++
++  // Device Req/Rsp FIFO
++  tlul_fifo_sync #(
++    .ReqPass    (DReqPass),
++    .RspPass    (DRspPass),
++    .ReqDepth   (DReqDepth),
++    .RspDepth   (DRspDepth),
++    .SpareReqW  (1)
++  ) u_devicefifo (
++    .clk_i,
++    .rst_ni,
++    .tl_h_i      (dreq_fifo_i),
++    .tl_h_o      (drsp_fifo_o),
++    .tl_d_o      (tl_d_o),
++    .tl_d_i      (tl_d_i),
++    .spare_req_i (1'b0),
++    .spare_req_o (),
++    .spare_rsp_i (1'b0),
++    .spare_rsp_o ()
++  );
++
++  // Request Arbiter
++  for (genvar i = 0 ; i < M ; i++) begin : gen_arbreqgnt
++    assign hrequest[i] = hreq_fifo_o[i].a_valid;
++  end
++
++  assign arb_ready = drsp_fifo_o.a_ready;
++
++  if (tlul_pkg::ArbiterImpl == "PPC") begin : gen_arb_ppc
++    prim_arbiter_ppc_surelog #(
++      .N      (M),
++      .DW     ($bits(tlul_pkg::tl_h2d_t))
++    ) u_reqarb (
++      .clk_i,
++      .rst_ni,
++      .req_i   ( hrequest    ),
++      .data_i  ( hreq_fifo_o ),
++      .gnt_o   ( hgrant      ),
++      .idx_o   (             ),
++      .valid_o ( arb_valid   ),
++      .data_o  ( arb_data    ),
++      .ready_i ( arb_ready   )
++    );
++  end else if (tlul_pkg::ArbiterImpl == "BINTREE") begin : gen_tree_arb
++    prim_arbiter_tree #(
++      .N      (M),
++      .DW     ($bits(tlul_pkg::tl_h2d_t))
++    ) u_reqarb (
++      .clk_i,
++      .rst_ni,
++      .req_i   ( hrequest    ),
++      .data_i  ( hreq_fifo_o ),
++      .gnt_o   ( hgrant      ),
++      .idx_o   (             ),
++      .valid_o ( arb_valid   ),
++      .data_o  ( arb_data    ),
++      .ready_i ( arb_ready   )
++    );
++  end else begin : gen_unknown
++    `ASSERT_INIT(UnknownArbImpl_A, 0)
++  end
++
++  logic [  M-1:0] hfifo_rspvalid;
++  logic [  M-1:0] dfifo_rspready;
++  logic [IDW-1:0] hfifo_rspid;
++  logic dfifo_rspready_merged;
++
++  // arb_data --> dreq_fifo_i
++  //   dreq_fifo_i.hd_rspready <= dfifo_rspready
++
++  assign dfifo_rspready_merged = |dfifo_rspready;
++  assign dreq_fifo_i = '{
++    a_valid:   arb_valid,
++    a_opcode:  arb_data.a_opcode,
++    a_param:   arb_data.a_param,
++    a_size:    arb_data.a_size,
++    a_source:  arb_data.a_source,
++    a_address: arb_data.a_address,
++    a_mask:    arb_data.a_mask,
++    a_data:    arb_data.a_data,
++    a_user:    arb_data.a_user,
++
++    d_ready:   dfifo_rspready_merged
++  };
++
++  // Response ID steering
++  // drsp_fifo_o --> hrsp_fifo_i[i]
++
++  // Response ID shifting before put into host fifo
++  assign hfifo_rspid = {
++    {STIDW{1'b0}},
++    drsp_fifo_o.d_source[IDW-1:STIDW]
++  };
++  for (genvar i = 0 ; i < M ; i++) begin : gen_idrouting
++    assign hfifo_rspvalid[i] = drsp_fifo_o.d_valid &
++                               (drsp_fifo_o.d_source[0+:STIDW] == i);
++    assign dfifo_rspready[i] = hreq_fifo_o[i].d_ready                &
++                               (drsp_fifo_o.d_source[0+:STIDW] == i) &
++                              drsp_fifo_o.d_valid;
++
++    assign hrsp_fifo_i[i].d_valid = hfifo_rspvalid[i];
++    assign hrsp_fifo_i[i].d_opcode = drsp_fifo_o.d_opcode;
++    assign hrsp_fifo_i[i].d_param = drsp_fifo_o.d_param;
++    assign hrsp_fifo_i[i].d_size = drsp_fifo_o.d_size;
++    assign hrsp_fifo_i[i].d_source = hfifo_rspid;
++    assign hrsp_fifo_i[i].d_sink = drsp_fifo_o.d_sink;
++    assign hrsp_fifo_i[i].d_data = drsp_fifo_o.d_data;
++    assign hrsp_fifo_i[i].d_user = drsp_fifo_o.d_user;
++    assign hrsp_fifo_i[i].d_error = drsp_fifo_o.d_error;
++    assign hrsp_fifo_i[i].a_ready = hgrant[i];
++  end
++
++  // this assertion fails when rspid[0+:STIDW] not in [0..M-1]
++  `ASSERT(rspIdInRange, drsp_fifo_o.d_valid |->
++      drsp_fifo_o.d_source[0+:STIDW] >= 0 && drsp_fifo_o.d_source[0+:STIDW] < M)
++
 +endmodule
 diff --git a/hw/ip/tlul/rtl/tlul_socket_m1_n2_depth.sv b/hw/ip/tlul/rtl/tlul_socket_m1_n2_depth.sv
 new file mode 100644

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -457,468 +457,6 @@ index 9ec473f85..86bef1e9d 100644
  
  endmodule : prim_arbiter_ppc
 -
-diff --git a/hw/ip/prim/rtl/prim_arbiter_ppc_n2.sv b/hw/ip/prim/rtl/prim_arbiter_ppc_n2.sv
-new file mode 100644
-index 000000000..d5542b139
---- /dev/null
-+++ b/hw/ip/prim/rtl/prim_arbiter_ppc_n2.sv
-@@ -0,0 +1,225 @@
-+// Copyright lowRISC contributors.
-+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-+// SPDX-License-Identifier: Apache-2.0
-+//
-+// N:1 arbiter module
-+//
-+// Verilog parameter
-+//   N:           Number of request ports
-+//   DW:          Data width
-+//   DataPort:    Set to 1 to enable the data port. Otherwise that port will be ignored.
-+//   EnReqStabA:  Checks whether requests remain asserted until granted
-+//
-+// This is the original implementation of the arbiter which relies on parallel prefix computing
-+// optimization to optimize the request / arbiter tree. Not all synthesis tools may support this.
-+//
-+// Note that the currently winning request is held if the data sink is not ready. This behavior is
-+// required by some interconnect protocols (AXI, TL). The module contains an assertion that checks
-+// this behavior.
-+//
-+// Also, this module contains a request stability assertion that checks that requests stay asserted
-+// until they have been served. This assertion can be optionally disabled by setting EnReqStabA to
-+// zero. This is a non-functional parameter and does not affect the designs behavior.
-+//
-+// See also: prim_arbiter_tree
-+
-+`include "prim_assert.sv"
-+
-+module prim_arbiter_ppc_n2 #(
-+  parameter int unsigned N  = 2,
-+  parameter int unsigned DW = 102,
-+
-+  // Configurations
-+  // EnDataPort: {0, 1}, if 0, input data will be ignored
-+  parameter bit EnDataPort = 1,
-+
-+  // Non-functional parameter to switch on the request stability assertion
-+  parameter bit EnReqStabA = 1,
-+
-+  // Derived parameters
-+  localparam int IdxW = $clog2(N)
-+) (
-+  input clk_i,
-+  input rst_ni,
-+
-+  input        [ N-1:0]    req_i,
-+  input        [(0 >= (N - 1) ? ((2 - N) * DW) + (((N - 1) * DW) - 1) : (N * DW) - 1):(0 >= (N - 1) ?(N - 1) * DW : 0)]    data_i,
-+  output logic [ N-1:0]    gnt_o,
-+  output logic [IdxW-1:0]  idx_o,
-+
-+  output logic             valid_o,
-+  output logic [DW-1:0]    data_o,
-+  input                    ready_i
-+);
-+
-+  `ASSERT_INIT(CheckNGreaterZero_A, N > 0)
-+
-+  // this case is basically just a bypass
-+  if (N == 1) begin : gen_degenerate_case
-+
-+    assign valid_o  = req_i[0];
-+    assign data_o   = data_i[0];
-+    assign gnt_o[0] = valid_o & ready_i;
-+    assign idx_o    = '0;
-+
-+  end else begin : gen_normal_case
-+
-+    logic [N-1:0] masked_req;
-+    logic [N-1:0] ppc_out;
-+    logic [N-1:0] arb_req;
-+    logic [N-1:0] mask, mask_next;
-+    logic [N-1:0] winner;
-+
-+    assign masked_req = mask & req_i;
-+    assign arb_req = (|masked_req) ? masked_req : req_i;
-+
-+    // PPC
-+    //   Even below code looks O(n) but DC optimizes it to O(log(N))
-+    //   Using Parallel Prefix Computation
-+    always_comb begin
-+      ppc_out[0] = arb_req[0];
-+      for (int i = 1 ; i < N ; i++) begin
-+        ppc_out[i] = ppc_out[i-1] | arb_req[i];
-+      end
-+    end
-+
-+    // Grant Generation: Leading-One detector
-+    assign winner = ppc_out ^ {ppc_out[N-2:0], 1'b0};
-+    assign gnt_o    = (ready_i) ? winner : '0;
-+
-+    assign valid_o = |req_i;
-+    // Mask Generation
-+    assign mask_next = {ppc_out[N-2:0], 1'b0};
-+    always_ff @(posedge clk_i or negedge rst_ni) begin
-+      if (!rst_ni) begin
-+        mask <= '0;
-+      end else if (valid_o && ready_i) begin
-+        // Latch only when requests accepted
-+        mask <= mask_next;
-+      end else if (valid_o && !ready_i) begin
-+        // Downstream isn't yet ready so, keep current request alive. (First come first serve)
-+        mask <= ppc_out;
-+      end
-+    end
-+
-+    if (EnDataPort == 1) begin: gen_datapath
-+      always_comb begin
-+        data_o = '0;
-+        for (int i = 0 ; i < N ; i++) begin
-+          if (winner[i]) begin
-+            data_o = data_i[(0 >= (N - 1) ? i : (N - 1) - i) * DW+:DW];
-+          end
-+        end
-+      end
-+    end else begin: gen_nodatapath
-+      assign data_o = '1;
-+      // TODO: waive data_i from NOT_READ error
-+    end
-+
-+    always_comb begin
-+      idx_o = '0;
-+      for (int i = 0 ; i < N ; i++) begin
-+        if (winner[i]) begin
-+          idx_o = i[IdxW-1:0];
-+        end
-+      end
-+    end
-+  end
-+
-+  ////////////////
-+  // assertions //
-+  ////////////////
-+
-+  // KNOWN assertions on outputs, except for data as that may be partially X in simulation
-+  // e.g. when used on a BUS
-+  `ASSERT_KNOWN(ValidKnown_A, valid_o)
-+  `ASSERT_KNOWN(GrantKnown_A, gnt_o)
-+  `ASSERT_KNOWN(IdxKnown_A, idx_o)
-+
-+  // grant index shall be higher index than previous index, unless no higher requests exist.
-+  `ASSERT(RoundRobin_A,
-+      ##1 valid_o && ready_i && $past(ready_i) && $past(valid_o) &&
-+      |(req_i & ~((N'(1) << $past(idx_o)+1) - 1)) |->
-+      idx_o > $past(idx_o))
-+  // we can only grant one requestor at a time
-+  `ASSERT(CheckHotOne_A, $onehot0(gnt_o))
-+  // A grant implies that the sink is ready
-+  `ASSERT(GntImpliesReady_A, |gnt_o |-> ready_i)
-+  // A grant implies that the arbiter asserts valid as well
-+  `ASSERT(GntImpliesValid_A, |gnt_o |-> valid_o)
-+  // A request and a sink that is ready imply a grant
-+  `ASSERT(ReqAndReadyImplyGrant_A, |req_i && ready_i |-> |gnt_o)
-+  // A request and a sink that is ready imply a grant
-+  `ASSERT(ReqImpliesValid_A, |req_i |-> valid_o)
-+  // Both conditions above combined and reversed
-+  `ASSERT(ReadyAndValidImplyGrant_A, ready_i && valid_o |-> |gnt_o)
-+  // Both conditions above combined and reversed
-+  `ASSERT(NoReadyValidNoGrant_A, !(ready_i || valid_o) |-> gnt_o == 0)
-+  // check index / grant correspond
-+  `ASSERT(IndexIsCorrect_A, ready_i && valid_o |-> gnt_o[idx_o] && req_i[idx_o])
-+
-+if (EnDataPort) begin: gen_data_port_assertion
-+  // data flow
-+  `ASSERT(DataFlow_A, ready_i && valid_o |-> data_o == data_i[idx_o])
-+end
-+
-+if (EnReqStabA) begin : gen_lock_assertion
-+  // requests must stay asserted until they have been granted
-+  `ASSUME(ReqStaysHighUntilGranted0_M, (|req_i) && !ready_i |=>
-+      (req_i & $past(req_i)) == $past(req_i))
-+  // check that the arbitration decision is held if the sink is not ready
-+  `ASSERT(LockArbDecision_A, |req_i && !ready_i |=> idx_o == $past(idx_o))
-+end
-+
-+// FPV-only assertions with symbolic variables
-+`ifdef FPV_ON
-+  // symbolic variables
-+  int unsigned k;
-+  bit ReadyIsStable;
-+  bit ReqsAreStable;
-+
-+  // constraints for symbolic variables
-+  `ASSUME(KStable_M, ##1 $stable(k))
-+  `ASSUME(KRange_M, k < N)
-+  // this is used enable checking for stable and unstable ready_i and req_i signals in the same run.
-+  // the symbolic variables act like a switch that the solver can trun on and off.
-+  `ASSUME(ReadyIsStable_M, ##1 $stable(ReadyIsStable))
-+  `ASSUME(ReqsAreStable_M, ##1 $stable(ReqsAreStable))
-+  `ASSUME(ReadyStable_M, ##1 !ReadyIsStable || $stable(ready_i))
-+  `ASSUME(ReqsStable_M, ##1 !ReqsAreStable || $stable(req_i))
-+
-+  // A grant implies a request
-+  `ASSERT(GntImpliesReq_A, gnt_o[k] |-> req_i[k])
-+
-+  // if request and ready are constantly held at 1, we should eventually get a grant
-+  `ASSERT(NoStarvation_A,
-+      ReqsAreStable && ReadyIsStable && ready_i && req_i[k] |->
-+      strong(##[0:$] gnt_o[k]))
-+
-+  // if N requests are constantly asserted and ready is constant 1, each request must
-+  // be granted exactly once over a time window of N cycles for the arbiter to be fair.
-+  for (genvar n = 1; n <= N; n++) begin : gen_fairness
-+    integer gnt_cnt;
-+    `ASSERT(Fairness_A,
-+        ReqsAreStable && ReadyIsStable && ready_i && req_i[k] &&
-+        $countones(req_i) == n |->
-+        ##n gnt_cnt == $past(gnt_cnt, n) + 1)
-+
-+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_cnt
-+      if (!rst_ni) begin
-+        gnt_cnt <= 0;
-+      end else begin
-+        gnt_cnt <= gnt_cnt + gnt_o[k];
-+      end
-+    end
-+  end
-+
-+  if (EnReqStabA) begin : gen_lock_assertion_fpv
-+    // requests must stay asserted until they have been granted
-+    `ASSUME(ReqStaysHighUntilGranted1_M, req_i[k] & !gnt_o[k] |=>
-+        req_i[k], clk_i, !rst_ni)
-+  end
-+`endif
-+
-+endmodule : prim_arbiter_ppc
-+
-diff --git a/hw/ip/prim/rtl/prim_arbiter_ppc_n3.sv b/hw/ip/prim/rtl/prim_arbiter_ppc_n3.sv
-new file mode 100644
-index 000000000..26b4c0908
---- /dev/null
-+++ b/hw/ip/prim/rtl/prim_arbiter_ppc_n3.sv
-@@ -0,0 +1,225 @@
-+// Copyright lowRISC contributors.
-+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-+// SPDX-License-Identifier: Apache-2.0
-+//
-+// N:1 arbiter module
-+//
-+// Verilog parameter
-+//   N:           Number of request ports
-+//   DW:          Data width
-+//   DataPort:    Set to 1 to enable the data port. Otherwise that port will be ignored.
-+//   EnReqStabA:  Checks whether requests remain asserted until granted
-+//
-+// This is the original implementation of the arbiter which relies on parallel prefix computing
-+// optimization to optimize the request / arbiter tree. Not all synthesis tools may support this.
-+//
-+// Note that the currently winning request is held if the data sink is not ready. This behavior is
-+// required by some interconnect protocols (AXI, TL). The module contains an assertion that checks
-+// this behavior.
-+//
-+// Also, this module contains a request stability assertion that checks that requests stay asserted
-+// until they have been served. This assertion can be optionally disabled by setting EnReqStabA to
-+// zero. This is a non-functional parameter and does not affect the designs behavior.
-+//
-+// See also: prim_arbiter_tree
-+
-+`include "prim_assert.sv"
-+
-+module prim_arbiter_ppc_n3 #(
-+  parameter int unsigned N  = 3,
-+  parameter int unsigned DW = 102,
-+
-+  // Configurations
-+  // EnDataPort: {0, 1}, if 0, input data will be ignored
-+  parameter bit EnDataPort = 1,
-+
-+  // Non-functional parameter to switch on the request stability assertion
-+  parameter bit EnReqStabA = 1,
-+
-+  // Derived parameters
-+  localparam int IdxW = $clog2(N)
-+) (
-+  input clk_i,
-+  input rst_ni,
-+
-+  input        [ N-1:0]    req_i,
-+  input        [(0 >= (N - 1) ? ((2 - N) * DW) + (((N - 1) * DW) - 1) : (N * DW) - 1):(0 >= (N - 1) ?(N - 1) * DW : 0)]    data_i,
-+  output logic [ N-1:0]    gnt_o,
-+  output logic [IdxW-1:0]  idx_o,
-+
-+  output logic             valid_o,
-+  output logic [DW-1:0]    data_o,
-+  input                    ready_i
-+);
-+
-+  `ASSERT_INIT(CheckNGreaterZero_A, N > 0)
-+
-+  // this case is basically just a bypass
-+  if (N == 1) begin : gen_degenerate_case
-+
-+    assign valid_o  = req_i[0];
-+    assign data_o   = data_i[0];
-+    assign gnt_o[0] = valid_o & ready_i;
-+    assign idx_o    = '0;
-+
-+  end else begin : gen_normal_case
-+
-+    logic [N-1:0] masked_req;
-+    logic [N-1:0] ppc_out;
-+    logic [N-1:0] arb_req;
-+    logic [N-1:0] mask, mask_next;
-+    logic [N-1:0] winner;
-+
-+    assign masked_req = mask & req_i;
-+    assign arb_req = (|masked_req) ? masked_req : req_i;
-+
-+    // PPC
-+    //   Even below code looks O(n) but DC optimizes it to O(log(N))
-+    //   Using Parallel Prefix Computation
-+    always_comb begin
-+      ppc_out[0] = arb_req[0];
-+      for (int i = 1 ; i < N ; i++) begin
-+        ppc_out[i] = ppc_out[i-1] | arb_req[i];
-+      end
-+    end
-+
-+    // Grant Generation: Leading-One detector
-+    assign winner = ppc_out ^ {ppc_out[N-2:0], 1'b0};
-+    assign gnt_o    = (ready_i) ? winner : '0;
-+
-+    assign valid_o = |req_i;
-+    // Mask Generation
-+    assign mask_next = {ppc_out[N-2:0], 1'b0};
-+    always_ff @(posedge clk_i or negedge rst_ni) begin
-+      if (!rst_ni) begin
-+        mask <= '0;
-+      end else if (valid_o && ready_i) begin
-+        // Latch only when requests accepted
-+        mask <= mask_next;
-+      end else if (valid_o && !ready_i) begin
-+        // Downstream isn't yet ready so, keep current request alive. (First come first serve)
-+        mask <= ppc_out;
-+      end
-+    end
-+
-+    if (EnDataPort == 1) begin: gen_datapath
-+      always_comb begin
-+        data_o = '0;
-+        for (int i = 0 ; i < N ; i++) begin
-+          if (winner[i]) begin
-+            data_o = data_i[(0 >= (N - 1) ? i : (N - 1) - i) * DW+:DW];
-+          end
-+        end
-+      end
-+    end else begin: gen_nodatapath
-+      assign data_o = '1;
-+      // TODO: waive data_i from NOT_READ error
-+    end
-+
-+    always_comb begin
-+      idx_o = '0;
-+      for (int i = 0 ; i < N ; i++) begin
-+        if (winner[i]) begin
-+          idx_o = i[IdxW-1:0];
-+        end
-+      end
-+    end
-+  end
-+
-+  ////////////////
-+  // assertions //
-+  ////////////////
-+
-+  // KNOWN assertions on outputs, except for data as that may be partially X in simulation
-+  // e.g. when used on a BUS
-+  `ASSERT_KNOWN(ValidKnown_A, valid_o)
-+  `ASSERT_KNOWN(GrantKnown_A, gnt_o)
-+  `ASSERT_KNOWN(IdxKnown_A, idx_o)
-+
-+  // grant index shall be higher index than previous index, unless no higher requests exist.
-+  `ASSERT(RoundRobin_A,
-+      ##1 valid_o && ready_i && $past(ready_i) && $past(valid_o) &&
-+      |(req_i & ~((N'(1) << $past(idx_o)+1) - 1)) |->
-+      idx_o > $past(idx_o))
-+  // we can only grant one requestor at a time
-+  `ASSERT(CheckHotOne_A, $onehot0(gnt_o))
-+  // A grant implies that the sink is ready
-+  `ASSERT(GntImpliesReady_A, |gnt_o |-> ready_i)
-+  // A grant implies that the arbiter asserts valid as well
-+  `ASSERT(GntImpliesValid_A, |gnt_o |-> valid_o)
-+  // A request and a sink that is ready imply a grant
-+  `ASSERT(ReqAndReadyImplyGrant_A, |req_i && ready_i |-> |gnt_o)
-+  // A request and a sink that is ready imply a grant
-+  `ASSERT(ReqImpliesValid_A, |req_i |-> valid_o)
-+  // Both conditions above combined and reversed
-+  `ASSERT(ReadyAndValidImplyGrant_A, ready_i && valid_o |-> |gnt_o)
-+  // Both conditions above combined and reversed
-+  `ASSERT(NoReadyValidNoGrant_A, !(ready_i || valid_o) |-> gnt_o == 0)
-+  // check index / grant correspond
-+  `ASSERT(IndexIsCorrect_A, ready_i && valid_o |-> gnt_o[idx_o] && req_i[idx_o])
-+
-+if (EnDataPort) begin: gen_data_port_assertion
-+  // data flow
-+  `ASSERT(DataFlow_A, ready_i && valid_o |-> data_o == data_i[idx_o])
-+end
-+
-+if (EnReqStabA) begin : gen_lock_assertion
-+  // requests must stay asserted until they have been granted
-+  `ASSUME(ReqStaysHighUntilGranted0_M, (|req_i) && !ready_i |=>
-+      (req_i & $past(req_i)) == $past(req_i))
-+  // check that the arbitration decision is held if the sink is not ready
-+  `ASSERT(LockArbDecision_A, |req_i && !ready_i |=> idx_o == $past(idx_o))
-+end
-+
-+// FPV-only assertions with symbolic variables
-+`ifdef FPV_ON
-+  // symbolic variables
-+  int unsigned k;
-+  bit ReadyIsStable;
-+  bit ReqsAreStable;
-+
-+  // constraints for symbolic variables
-+  `ASSUME(KStable_M, ##1 $stable(k))
-+  `ASSUME(KRange_M, k < N)
-+  // this is used enable checking for stable and unstable ready_i and req_i signals in the same run.
-+  // the symbolic variables act like a switch that the solver can trun on and off.
-+  `ASSUME(ReadyIsStable_M, ##1 $stable(ReadyIsStable))
-+  `ASSUME(ReqsAreStable_M, ##1 $stable(ReqsAreStable))
-+  `ASSUME(ReadyStable_M, ##1 !ReadyIsStable || $stable(ready_i))
-+  `ASSUME(ReqsStable_M, ##1 !ReqsAreStable || $stable(req_i))
-+
-+  // A grant implies a request
-+  `ASSERT(GntImpliesReq_A, gnt_o[k] |-> req_i[k])
-+
-+  // if request and ready are constantly held at 1, we should eventually get a grant
-+  `ASSERT(NoStarvation_A,
-+      ReqsAreStable && ReadyIsStable && ready_i && req_i[k] |->
-+      strong(##[0:$] gnt_o[k]))
-+
-+  // if N requests are constantly asserted and ready is constant 1, each request must
-+  // be granted exactly once over a time window of N cycles for the arbiter to be fair.
-+  for (genvar n = 1; n <= N; n++) begin : gen_fairness
-+    integer gnt_cnt;
-+    `ASSERT(Fairness_A,
-+        ReqsAreStable && ReadyIsStable && ready_i && req_i[k] &&
-+        $countones(req_i) == n |->
-+        ##n gnt_cnt == $past(gnt_cnt, n) + 1)
-+
-+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_cnt
-+      if (!rst_ni) begin
-+        gnt_cnt <= 0;
-+      end else begin
-+        gnt_cnt <= gnt_cnt + gnt_o[k];
-+      end
-+    end
-+  end
-+
-+  if (EnReqStabA) begin : gen_lock_assertion_fpv
-+    // requests must stay asserted until they have been granted
-+    `ASSUME(ReqStaysHighUntilGranted1_M, req_i[k] & !gnt_o[k] |=>
-+        req_i[k], clk_i, !rst_ni)
-+  end
-+`endif
-+
-+endmodule : prim_arbiter_ppc
-+
 diff --git a/hw/ip/prim/rtl/prim_arbiter_ppc_surelog.sv b/hw/ip/prim/rtl/prim_arbiter_ppc_surelog.sv
 new file mode 100644
 index 000000000..af3ca8939
@@ -2496,10 +2034,10 @@ index 000000000..91089db3a
 +endmodule
 diff --git a/hw/ip/tlul/rtl/tlul_socket_m1_n2_depth.sv b/hw/ip/tlul/rtl/tlul_socket_m1_n2_depth.sv
 new file mode 100644
-index 000000000..57f6f4410
+index 000000000..1007785d1
 --- /dev/null
 +++ b/hw/ip/tlul/rtl/tlul_socket_m1_n2_depth.sv
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,256 @@
 +// Copyright lowRISC contributors.
 +// Licensed under the Apache License, Version 2.0, see LICENSE for details.
 +// SPDX-License-Identifier: Apache-2.0
@@ -2535,169 +2073,233 @@ index 000000000..57f6f4410
 +  parameter bit [3:0]     DReqDepth = 4'h0,
 +  parameter bit [3:0]     DRspDepth = 4'h0
 +) (
-+	input clk_i,
-+	input rst_ni,
-+	input wire [(0 >= (M - 1) ? ((2 - M) * 102) + (((M - 1) * 102) - 1) : (M * 102) - 1):(0 >= (M - 1) ? (M - 1) * 102 : 0)] tl_h_i,
-+	output wire [(0 >= (M - 1) ? ((2 - M) * 68) + (((M - 1) * 68) - 1) : (M * 68) - 1):(0 >= (M - 1) ? (M - 1) * 68 : 0)] tl_h_o,
-+	output wire [101:0] tl_d_o,
-+	input wire [67:0] tl_d_i
++  input                     clk_i,
++  input                     rst_ni,
++
++  input  tlul_pkg::tl_h2d_t tl_h_i [M],
++  output tlul_pkg::tl_d2h_t tl_h_o [M],
++
++  output tlul_pkg::tl_h2d_t tl_d_o,
++  input  tlul_pkg::tl_d2h_t tl_d_i
 +);
-+	localparam signed [31:0] top_pkg_TL_AIW = 8;
-+	localparam signed [31:0] top_pkg_TL_AW = 32;
-+	localparam signed [31:0] top_pkg_TL_DW = 32;
-+	localparam signed [31:0] top_pkg_TL_DBW = 4;
-+	localparam signed [31:0] top_pkg_TL_SZW = 2;
-+	localparam signed [31:0] top_pkg_TL_DIW = 1;
-+	localparam signed [31:0] top_pkg_TL_DUW = 16;
-+	localparam [31:0] IDW = top_pkg_TL_AIW;
-+	localparam [31:0] STIDW = $clog2(M);
-+	wire [(0 >= (M - 1) ? ((2 - M) * 102) + (((M - 1) * 102) - 1) : (M * 102) - 1):(0 >= (M - 1) ? (M - 1) * 102 : 0)] hreq_fifo_o;
-+	wire [67:0] hrsp_fifo_i [0:M - 1];
-+	wire [M - 1:0] hrequest;
-+	wire [M - 1:0] hgrant;
-+	wire [101:0] dreq_fifo_i;
-+	wire [67:0] drsp_fifo_o;
-+	wire arb_valid;
-+	wire arb_ready;
-+	wire [101:0] arb_data;
-+	generate
-+		genvar i;
-+		for (i = 0; i < M; i = i + 1) begin : gen_host_fifo
-+			wire [101:0] hreq_fifo_i;
-+			wire [STIDW - 1:0] reqid_sub;
-+			wire [7:0] shifted_id;
-+			assign reqid_sub = i;
-+			assign shifted_id = {tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 85+:IDW - STIDW], reqid_sub};
-+			wire [7:IDW - STIDW] unused_tl_h_source;
-+			assign unused_tl_h_source = tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 92-:STIDW];
-+			assign hreq_fifo_i = {tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 101],
-+			                      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 100:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 100-3+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 97:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 97-3+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 94:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 94-2+1],
-+					      shifted_id,
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 84:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 84-32+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 52:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 52-4+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 48:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 48-top_pkg_TL_DW+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 16:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 16-16+1],
-+					      tl_h_i[(0 >= (M - 1) ? i : (M - 1) - i) * 102]};
-+			tlul_fifo_sync #(
-+				.ReqPass(HReqPass[i]),
-+				.RspPass(HRspPass[i]),
-+				.ReqDepth(HReqDepth[i * 4+:4]),
-+				.RspDepth(HRspDepth[i * 4+:4]),
-+				.SpareReqW(1)
-+			) u_hostfifo(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.tl_h_i(hreq_fifo_i),
-+				.tl_h_o(tl_h_o[(0 >= (M - 1) ? i : (M - 1) - i) * 68+:68]),
-+				.tl_d_o(hreq_fifo_o[(0 >= (M - 1) ? i : (M - 1) - i) * 102+:102]),
-+				.tl_d_i(hrsp_fifo_i[i]),
-+				.spare_req_i(1'b0),
-+				.spare_req_o(),
-+				.spare_rsp_i(1'b0),
-+				.spare_rsp_o()
-+			);
-+		end
-+	endgenerate
-+	tlul_fifo_sync #(
-+		.ReqPass(DReqPass),
-+		.RspPass(DRspPass),
-+		.ReqDepth(DReqDepth),
-+		.RspDepth(DRspDepth),
-+		.SpareReqW(1)
-+	) u_devicefifo(
-+		.clk_i(clk_i),
-+		.rst_ni(rst_ni),
-+		.tl_h_i(dreq_fifo_i),
-+		.tl_h_o(drsp_fifo_o),
-+		.tl_d_o(tl_d_o),
-+		.tl_d_i(tl_d_i),
-+		.spare_req_i(1'b0),
-+		.spare_req_o(),
-+		.spare_rsp_i(1'b0),
-+		.spare_rsp_o()
-+	);
-+	generate
-+		for (i = 0; i < M; i = i + 1) begin : gen_arbreqgnt
-+			assign hrequest[i] = hreq_fifo_o[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 101];
-+		end
-+	endgenerate
-+	assign arb_ready = drsp_fifo_o[0];
-+	localparam tlul_pkg_ArbiterImpl = "PPC";
-+	generate
-+		if (tlul_pkg_ArbiterImpl == "PPC") begin : gen_arb_ppc
-+			prim_arbiter_ppc_surelog #(
-+				.N(M),
-+				.DW(102)
-+			) u_reqarb(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.req_i(hrequest),
-+				.data_i(hreq_fifo_o),
-+				.gnt_o(hgrant),
-+				.idx_o(),
-+				.valid_o(arb_valid),
-+				.data_o(arb_data),
-+				.ready_i(arb_ready)
-+			);
-+		end
-+		else if (tlul_pkg_ArbiterImpl == "BINTREE") begin : gen_tree_arb
-+			prim_arbiter_tree #(
-+				.N(M),
-+				.DW(102)
-+			) u_reqarb(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.req_i(hrequest),
-+				.data_i(hreq_fifo_o),
-+				.gnt_o(hgrant),
-+				.idx_o(),
-+				.valid_o(arb_valid),
-+				.data_o(arb_data),
-+				.ready_i(arb_ready)
-+			);
-+		end
-+	endgenerate
-+	wire [M - 1:0] hfifo_rspvalid;
-+	wire [M - 1:0] dfifo_rspready;
-+	wire [7:0] hfifo_rspid;
-+	wire dfifo_rspready_merged;
-+	assign dfifo_rspready_merged = |dfifo_rspready;
-+	assign dreq_fifo_i = {arb_valid,
-+	                      arb_data[100:100-3+1],
-+			      arb_data[97:97-3+1],
-+			      arb_data[94:94-2+1],
-+			      arb_data[92:92-8+1],
-+			      arb_data[84:84-32+1],
-+			      arb_data[52:52-4+1],
-+			      arb_data[48:48-top_pkg_TL_DW+1],
-+			      arb_data[16:16-16+1],
-+			      dfifo_rspready_merged};
-+	assign hfifo_rspid = {{STIDW {1'b0}}, drsp_fifo_o[58:51 + STIDW]};
-+	generate
-+		for (i = 0; i < M; i = i + 1) begin : gen_idrouting
-+			assign hfifo_rspvalid[i] = drsp_fifo_o[67] & (drsp_fifo_o[51+:STIDW] == i);
-+			assign dfifo_rspready[i] = (hreq_fifo_o[(0 >= (M - 1) ? i : (M - 1) - i) * 102] & (drsp_fifo_o[51+:STIDW] == i)) & drsp_fifo_o[67];
-+			assign hrsp_fifo_i[i] = {hfifo_rspvalid[i],
-+			                         drsp_fifo_o[66:66-3+1],
-+						 drsp_fifo_o[63:63-3+1],
-+						 drsp_fifo_o[60:60-2+1],
-+						 hfifo_rspid,
-+						 drsp_fifo_o[50:50-1+1],
-+						 drsp_fifo_o[49:49-32+1],
-+						 drsp_fifo_o[17:17-top_pkg_TL_DUW+1],
-+						 drsp_fifo_o[1],
-+						 hgrant[i]};
-+		end
-+	endgenerate
++
++  `ASSERT_INIT(maxM, M < 16)
++
++
++  // Signals
++  //
++  //  tl_h_i/o[0] |  tl_h_i/o[1] | ... |  tl_h_i/o[M-1]
++  //      |              |                    |
++  // u_hostfifo[0]  u_hostfifo[1]        u_hostfifo[M-1]
++  //      |              |                    |
++  //       hreq_fifo_o(i) / hrsp_fifo_i(i)
++  //     ---------------------------------------
++  //     |       request/grant/req_data        |
++  //     |                                     |
++  //     |           PRIM_ARBITER              |
++  //     |                                     |
++  //     |  arb_valid / arb_ready / arb_data   |
++  //     ---------------------------------------
++  //                     |
++  //                dreq_fifo_i / drsp_fifo_o
++  //                     |
++  //                u_devicefifo
++  //                     |
++  //                  tl_d_o/i
++  //
++  // Required ID width to distinguish between host ports
++  //  Used in response steering
++  localparam int unsigned IDW   = top_pkg::TL_AIW;
++  localparam int unsigned STIDW = $clog2(M);
++
++  tlul_pkg::tl_h2d_t hreq_fifo_o [M];
++  tlul_pkg::tl_d2h_t hrsp_fifo_i [M];
++
++  logic [M-1:0] hrequest;
++  logic [M-1:0] hgrant;
++
++  tlul_pkg::tl_h2d_t dreq_fifo_i;
++  tlul_pkg::tl_d2h_t drsp_fifo_o;
++
++  logic arb_valid;
++  logic arb_ready;
++  tlul_pkg::tl_h2d_t arb_data;
++
++  // Host Req/Rsp FIFO
++  for (genvar i = 0 ; i < M ; i++) begin : gen_host_fifo
++    tlul_pkg::tl_h2d_t hreq_fifo_i;
++
++    // ID Shifting
++    logic [STIDW-1:0] reqid_sub;
++    logic [IDW-1:0] shifted_id;
++    logic [7:0] tmp;
++    assign tmp = tl_h_i[i].a_source;
++    assign reqid_sub = i;   // can cause conversion error?
++    assign shifted_id = {
++      tmp[0+:(IDW-STIDW)],
++      reqid_sub
++    };
++
++  `ASSERT(idInRange, tl_h_i[i].a_valid |-> tl_h_i[i].a_source[IDW-1 -:STIDW] == '0)
++
++    // assign not connected bits to nc_* signal to make lint happy
++    logic [IDW-1 : IDW-STIDW] unused_tl_h_source;
++    assign unused_tl_h_source = tmp[IDW-1 -: STIDW];
++
++    // Put shifted ID
++    assign hreq_fifo_i.a_valid = tl_h_i[i].a_valid;
++    assign hreq_fifo_i.a_opcode = tl_h_i[i].a_opcode;
++    assign hreq_fifo_i.a_param = tl_h_i[i].a_param;
++    assign hreq_fifo_i.a_size = tl_h_i[i].a_size;
++    assign hreq_fifo_i.a_source = shifted_id;
++    assign hreq_fifo_i.a_address = tl_h_i[i].a_address;
++    assign hreq_fifo_i.a_mask = tl_h_i[i].a_mask;
++    assign hreq_fifo_i.a_data = tl_h_i[i].a_data;
++    assign hreq_fifo_i.a_user = tl_h_i[i].a_user;
++    assign hreq_fifo_i.d_ready = tl_h_i[i].d_ready;
++
++    tlul_fifo_sync #(
++      .ReqPass    (HReqPass[i]),
++      .RspPass    (HRspPass[i]),
++      .ReqDepth   (HReqDepth[i*4+:4]),
++      .RspDepth   (HRspDepth[i*4+:4]),
++      .SpareReqW  (1)
++    ) u_hostfifo (
++      .clk_i,
++      .rst_ni,
++      .tl_h_i      (hreq_fifo_i),
++      .tl_h_o      (tl_h_o[i]),
++      .tl_d_o      (hreq_fifo_o[i]),
++      .tl_d_i      (hrsp_fifo_i[i]),
++      .spare_req_i (1'b0),
++      .spare_req_o (),
++      .spare_rsp_i (1'b0),
++      .spare_rsp_o ()
++    );
++  end
++
++  // Device Req/Rsp FIFO
++  tlul_fifo_sync #(
++    .ReqPass    (DReqPass),
++    .RspPass    (DRspPass),
++    .ReqDepth   (DReqDepth),
++    .RspDepth   (DRspDepth),
++    .SpareReqW  (1)
++  ) u_devicefifo (
++    .clk_i,
++    .rst_ni,
++    .tl_h_i      (dreq_fifo_i),
++    .tl_h_o      (drsp_fifo_o),
++    .tl_d_o      (tl_d_o),
++    .tl_d_i      (tl_d_i),
++    .spare_req_i (1'b0),
++    .spare_req_o (),
++    .spare_rsp_i (1'b0),
++    .spare_rsp_o ()
++  );
++
++  // Request Arbiter
++  for (genvar i = 0 ; i < M ; i++) begin : gen_arbreqgnt
++    assign hrequest[i] = hreq_fifo_o[i].a_valid;
++  end
++
++  assign arb_ready = drsp_fifo_o.a_ready;
++
++  if (tlul_pkg::ArbiterImpl == "PPC") begin : gen_arb_ppc
++    prim_arbiter_ppc_surelog #(
++      .N      (M),
++      .DW     ($bits(tlul_pkg::tl_h2d_t))
++    ) u_reqarb (
++      .clk_i,
++      .rst_ni,
++      .req_i   ( hrequest    ),
++      .data_i  ( hreq_fifo_o ),
++      .gnt_o   ( hgrant      ),
++      .idx_o   (             ),
++      .valid_o ( arb_valid   ),
++      .data_o  ( arb_data    ),
++      .ready_i ( arb_ready   )
++    );
++  end else if (tlul_pkg::ArbiterImpl == "BINTREE") begin : gen_tree_arb
++    prim_arbiter_tree #(
++      .N      (M),
++      .DW     ($bits(tlul_pkg::tl_h2d_t))
++    ) u_reqarb (
++      .clk_i,
++      .rst_ni,
++      .req_i   ( hrequest    ),
++      .data_i  ( hreq_fifo_o ),
++      .gnt_o   ( hgrant      ),
++      .idx_o   (             ),
++      .valid_o ( arb_valid   ),
++      .data_o  ( arb_data    ),
++      .ready_i ( arb_ready   )
++    );
++  end else begin : gen_unknown
++    `ASSERT_INIT(UnknownArbImpl_A, 0)
++  end
++
++  logic [  M-1:0] hfifo_rspvalid;
++  logic [  M-1:0] dfifo_rspready;
++  logic [IDW-1:0] hfifo_rspid;
++  logic dfifo_rspready_merged;
++
++  // arb_data --> dreq_fifo_i
++  //   dreq_fifo_i.hd_rspready <= dfifo_rspready
++
++  assign dfifo_rspready_merged = |dfifo_rspready;
++  assign dreq_fifo_i = '{
++    a_valid:   arb_valid,
++    a_opcode:  arb_data.a_opcode,
++    a_param:   arb_data.a_param,
++    a_size:    arb_data.a_size,
++    a_source:  arb_data.a_source,
++    a_address: arb_data.a_address,
++    a_mask:    arb_data.a_mask,
++    a_data:    arb_data.a_data,
++    a_user:    arb_data.a_user,
++
++    d_ready:   dfifo_rspready_merged
++  };
++
++  // Response ID steering
++  // drsp_fifo_o --> hrsp_fifo_i[i]
++
++  // Response ID shifting before put into host fifo
++  assign hfifo_rspid = {
++    {STIDW{1'b0}},
++    drsp_fifo_o.d_source[IDW-1:STIDW]
++  };
++  for (genvar i = 0 ; i < M ; i++) begin : gen_idrouting
++    assign hfifo_rspvalid[i] = drsp_fifo_o.d_valid &
++                               (drsp_fifo_o.d_source[0+:STIDW] == i);
++    assign dfifo_rspready[i] = hreq_fifo_o[i].d_ready                &
++                               (drsp_fifo_o.d_source[0+:STIDW] == i) &
++                              drsp_fifo_o.d_valid;
++
++    assign hrsp_fifo_i[i].d_valid = hfifo_rspvalid[i];
++    assign hrsp_fifo_i[i].d_opcode = drsp_fifo_o.d_opcode;
++    assign hrsp_fifo_i[i].d_param = drsp_fifo_o.d_param;
++    assign hrsp_fifo_i[i].d_size = drsp_fifo_o.d_size;
++    assign hrsp_fifo_i[i].d_source = hfifo_rspid;
++    assign hrsp_fifo_i[i].d_sink = drsp_fifo_o.d_sink;
++    assign hrsp_fifo_i[i].d_data = drsp_fifo_o.d_data;
++    assign hrsp_fifo_i[i].d_user = drsp_fifo_o.d_user;
++    assign hrsp_fifo_i[i].d_error = drsp_fifo_o.d_error;
++    assign hrsp_fifo_i[i].a_ready = hgrant[i];
++  end
++
++  // this assertion fails when rspid[0+:STIDW] not in [0..M-1]
++  `ASSERT(rspIdInRange, drsp_fifo_o.d_valid |->
++      drsp_fifo_o.d_source[0+:STIDW] >= 0 && drsp_fifo_o.d_source[0+:STIDW] < M)
++
 +endmodule
 diff --git a/hw/ip/tlul/rtl/tlul_socket_m1_n3.sv b/hw/ip/tlul/rtl/tlul_socket_m1_n3.sv
 new file mode 100644
-index 000000000..df2f80214
+index 000000000..14eae9755
 --- /dev/null
 +++ b/hw/ip/tlul/rtl/tlul_socket_m1_n3.sv
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,256 @@
 +// Copyright lowRISC contributors.
 +// Licensed under the Apache License, Version 2.0, see LICENSE for details.
 +// SPDX-License-Identifier: Apache-2.0
@@ -2733,162 +2335,226 @@ index 000000000..df2f80214
 +  parameter bit [3:0]     DReqDepth = 4'h0,
 +  parameter bit [3:0]     DRspDepth = 4'h0
 +) (
-+	input clk_i,
-+	input rst_ni,
-+	input wire [(0 >= (M - 1) ? ((2 - M) * 102) + (((M - 1) * 102) - 1) : (M * 102) - 1):(0 >= (M - 1) ? (M - 1) * 102 : 0)] tl_h_i,
-+	output wire [(0 >= (M - 1) ? ((2 - M) * 68) + (((M - 1) * 68) - 1) : (M * 68) - 1):(0 >= (M - 1) ? (M - 1) * 68 : 0)] tl_h_o,
-+	output wire [101:0] tl_d_o,
-+	input wire [67:0] tl_d_i
++  input                     clk_i,
++  input                     rst_ni,
++
++  input  tlul_pkg::tl_h2d_t tl_h_i [M],
++  output tlul_pkg::tl_d2h_t tl_h_o [M],
++
++  output tlul_pkg::tl_h2d_t tl_d_o,
++  input  tlul_pkg::tl_d2h_t tl_d_i
 +);
-+	localparam signed [31:0] top_pkg_TL_AIW = 8;
-+	localparam signed [31:0] top_pkg_TL_AW = 32;
-+	localparam signed [31:0] top_pkg_TL_DW = 32;
-+	localparam signed [31:0] top_pkg_TL_DBW = 4;
-+	localparam signed [31:0] top_pkg_TL_SZW = 2;
-+	localparam signed [31:0] top_pkg_TL_DIW = 1;
-+	localparam signed [31:0] top_pkg_TL_DUW = 16;
-+	localparam [31:0] IDW = top_pkg_TL_AIW;
-+	localparam [31:0] STIDW = $clog2(M);
-+	wire [(0 >= (M - 1) ? ((2 - M) * 102) + (((M - 1) * 102) - 1) : (M * 102) - 1):(0 >= (M - 1) ? (M - 1) * 102 : 0)] hreq_fifo_o;
-+	wire [67:0] hrsp_fifo_i [0:M - 1];
-+	wire [M - 1:0] hrequest;
-+	wire [M - 1:0] hgrant;
-+	wire [101:0] dreq_fifo_i;
-+	wire [67:0] drsp_fifo_o;
-+	wire arb_valid;
-+	wire arb_ready;
-+	wire [101:0] arb_data;
-+	generate
-+		genvar i;
-+		for (i = 0; i < M; i = i + 1) begin : gen_host_fifo
-+			wire [101:0] hreq_fifo_i;
-+			wire [STIDW - 1:0] reqid_sub;
-+			wire [7:0] shifted_id;
-+			assign reqid_sub = i;
-+			assign shifted_id = {tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 85+:IDW - STIDW], reqid_sub};
-+			wire [7:IDW - STIDW] unused_tl_h_source;
-+			assign unused_tl_h_source = tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 92:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 92 - STIDW + 1];
-+			assign hreq_fifo_i = {tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 101],
-+			                      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 100:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 100-3+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 97:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 97-3+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 94:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 94-2+1],
-+					      shifted_id,
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 84:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 84-32+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 52:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 52-4+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 48:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 48-top_pkg_TL_DW+1],
-+					      tl_h_i[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 16:((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 16-16+1],
-+					      tl_h_i[(0 >= (M - 1) ? i : (M - 1) - i) * 102]};
-+			tlul_fifo_sync #(
-+				.ReqPass(HReqPass[i]),
-+				.RspPass(HRspPass[i]),
-+				.ReqDepth(HReqDepth[i * 4+:4]),
-+				.RspDepth(HRspDepth[i * 4+:4]),
-+				.SpareReqW(1)
-+			) u_hostfifo(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.tl_h_i(hreq_fifo_i),
-+				.tl_h_o(tl_h_o[(0 >= (M - 1) ? i : (M - 1) - i) * 68+:68]),
-+				.tl_d_o(hreq_fifo_o[(0 >= (M - 1) ? i : (M - 1) - i) * 102+:102]),
-+				.tl_d_i(hrsp_fifo_i[i]),
-+				.spare_req_i(1'b0),
-+				.spare_req_o(),
-+				.spare_rsp_i(1'b0),
-+				.spare_rsp_o()
-+			);
-+		end
-+	endgenerate
-+	tlul_fifo_sync #(
-+		.ReqPass(DReqPass),
-+		.RspPass(DRspPass),
-+		.ReqDepth(DReqDepth),
-+		.RspDepth(DRspDepth),
-+		.SpareReqW(1)
-+	) u_devicefifo(
-+		.clk_i(clk_i),
-+		.rst_ni(rst_ni),
-+		.tl_h_i(dreq_fifo_i),
-+		.tl_h_o(drsp_fifo_o),
-+		.tl_d_o(tl_d_o),
-+		.tl_d_i(tl_d_i),
-+		.spare_req_i(1'b0),
-+		.spare_req_o(),
-+		.spare_rsp_i(1'b0),
-+		.spare_rsp_o()
-+	);
-+	generate
-+		for (i = 0; i < M; i = i + 1) begin : gen_arbreqgnt
-+			assign hrequest[i] = hreq_fifo_o[((0 >= (M - 1) ? i : (M - 1) - i) * 102) + 101];
-+		end
-+	endgenerate
-+	assign arb_ready = drsp_fifo_o[0];
-+	localparam tlul_pkg_ArbiterImpl = "PPC";
-+	generate
-+		if (tlul_pkg_ArbiterImpl == "PPC") begin : gen_arb_ppc
-+			prim_arbiter_ppc_surelog #(
-+				.N(M),
-+				.DW(102)
-+			) u_reqarb(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.req_i(hrequest),
-+				.data_i(hreq_fifo_o),
-+				.gnt_o(hgrant),
-+				.idx_o(),
-+				.valid_o(arb_valid),
-+				.data_o(arb_data),
-+				.ready_i(arb_ready)
-+			);
-+		end
-+		else if (tlul_pkg_ArbiterImpl == "BINTREE") begin : gen_tree_arb
-+			prim_arbiter_tree #(
-+				.N(M),
-+				.DW(102)
-+			) u_reqarb(
-+				.clk_i(clk_i),
-+				.rst_ni(rst_ni),
-+				.req_i(hrequest),
-+				.data_i(hreq_fifo_o),
-+				.gnt_o(hgrant),
-+				.idx_o(),
-+				.valid_o(arb_valid),
-+				.data_o(arb_data),
-+				.ready_i(arb_ready)
-+			);
-+		end
-+	endgenerate
-+	wire [M - 1:0] hfifo_rspvalid;
-+	wire [M - 1:0] dfifo_rspready;
-+	wire [7:0] hfifo_rspid;
-+	wire dfifo_rspready_merged;
-+	assign dfifo_rspready_merged = |dfifo_rspready;
-+	assign dreq_fifo_i = {arb_valid,
-+	                      arb_data[100:100-3+1],
-+			      arb_data[97:97-3+1],
-+			      arb_data[94:94-2+1],
-+			      arb_data[92:92-8+1],
-+			      arb_data[84:84-32+1],
-+			      arb_data[52:52-4+1],
-+			      arb_data[48:48-top_pkg_TL_DW+1],
-+			      arb_data[16:16-16+1],
-+			      dfifo_rspready_merged};
-+	assign hfifo_rspid = {{STIDW {1'b0}}, drsp_fifo_o[58:51 + STIDW]};
-+	generate
-+		for (i = 0; i < M; i = i + 1) begin : gen_idrouting
-+			assign hfifo_rspvalid[i] = drsp_fifo_o[67] & (drsp_fifo_o[51+:STIDW] == i);
-+			assign dfifo_rspready[i] = (hreq_fifo_o[(0 >= (M - 1) ? i : (M - 1) - i) * 102] & (drsp_fifo_o[51+:STIDW] == i)) & drsp_fifo_o[67];
-+			assign hrsp_fifo_i[i] = {hfifo_rspvalid[i],
-+			                         drsp_fifo_o[66:66-3+1],
-+						 drsp_fifo_o[63:63-3+1],
-+						 drsp_fifo_o[60:60-2+1],
-+						 hfifo_rspid,
-+						 drsp_fifo_o[50:50-1+1],
-+						 drsp_fifo_o[49:49-32+1],
-+						 drsp_fifo_o[17:17-top_pkg_TL_DUW+1],
-+						 drsp_fifo_o[1],
-+						 hgrant[i]};
-+		end
-+	endgenerate
++
++  `ASSERT_INIT(maxM, M < 16)
++
++
++  // Signals
++  //
++  //  tl_h_i/o[0] |  tl_h_i/o[1] | ... |  tl_h_i/o[M-1]
++  //      |              |                    |
++  // u_hostfifo[0]  u_hostfifo[1]        u_hostfifo[M-1]
++  //      |              |                    |
++  //       hreq_fifo_o(i) / hrsp_fifo_i(i)
++  //     ---------------------------------------
++  //     |       request/grant/req_data        |
++  //     |                                     |
++  //     |           PRIM_ARBITER              |
++  //     |                                     |
++  //     |  arb_valid / arb_ready / arb_data   |
++  //     ---------------------------------------
++  //                     |
++  //                dreq_fifo_i / drsp_fifo_o
++  //                     |
++  //                u_devicefifo
++  //                     |
++  //                  tl_d_o/i
++  //
++  // Required ID width to distinguish between host ports
++  //  Used in response steering
++  localparam int unsigned IDW   = top_pkg::TL_AIW;
++  localparam int unsigned STIDW = $clog2(M);
++
++  tlul_pkg::tl_h2d_t hreq_fifo_o [M];
++  tlul_pkg::tl_d2h_t hrsp_fifo_i [M];
++
++  logic [M-1:0] hrequest;
++  logic [M-1:0] hgrant;
++
++  tlul_pkg::tl_h2d_t dreq_fifo_i;
++  tlul_pkg::tl_d2h_t drsp_fifo_o;
++
++  logic arb_valid;
++  logic arb_ready;
++  tlul_pkg::tl_h2d_t arb_data;
++
++  // Host Req/Rsp FIFO
++  for (genvar i = 0 ; i < M ; i++) begin : gen_host_fifo
++    tlul_pkg::tl_h2d_t hreq_fifo_i;
++
++    // ID Shifting
++    logic [STIDW-1:0] reqid_sub;
++    logic [IDW-1:0] shifted_id;
++    logic [7:0] tmp;
++    assign tmp = tl_h_i[i].a_source;
++    assign reqid_sub = i;   // can cause conversion error?
++    assign shifted_id = {
++      tmp[0+:(IDW-STIDW)],
++      reqid_sub
++    };
++
++  `ASSERT(idInRange, tl_h_i[i].a_valid |-> tl_h_i[i].a_source[IDW-1 -:STIDW] == '0)
++
++    // assign not connected bits to nc_* signal to make lint happy
++    logic [IDW-1 : IDW-STIDW] unused_tl_h_source;
++    assign unused_tl_h_source = tmp[IDW-1 -: STIDW];
++
++    // Put shifted ID
++    assign hreq_fifo_i.a_valid = tl_h_i[i].a_valid;
++    assign hreq_fifo_i.a_opcode = tl_h_i[i].a_opcode;
++    assign hreq_fifo_i.a_param = tl_h_i[i].a_param;
++    assign hreq_fifo_i.a_size = tl_h_i[i].a_size;
++    assign hreq_fifo_i.a_source = shifted_id;
++    assign hreq_fifo_i.a_address = tl_h_i[i].a_address;
++    assign hreq_fifo_i.a_mask = tl_h_i[i].a_mask;
++    assign hreq_fifo_i.a_data = tl_h_i[i].a_data;
++    assign hreq_fifo_i.a_user = tl_h_i[i].a_user;
++    assign hreq_fifo_i.d_ready = tl_h_i[i].d_ready;
++
++    tlul_fifo_sync #(
++      .ReqPass    (HReqPass[i]),
++      .RspPass    (HRspPass[i]),
++      .ReqDepth   (HReqDepth[i*4+:4]),
++      .RspDepth   (HRspDepth[i*4+:4]),
++      .SpareReqW  (1)
++    ) u_hostfifo (
++      .clk_i,
++      .rst_ni,
++      .tl_h_i      (hreq_fifo_i),
++      .tl_h_o      (tl_h_o[i]),
++      .tl_d_o      (hreq_fifo_o[i]),
++      .tl_d_i      (hrsp_fifo_i[i]),
++      .spare_req_i (1'b0),
++      .spare_req_o (),
++      .spare_rsp_i (1'b0),
++      .spare_rsp_o ()
++    );
++  end
++
++  // Device Req/Rsp FIFO
++  tlul_fifo_sync #(
++    .ReqPass    (DReqPass),
++    .RspPass    (DRspPass),
++    .ReqDepth   (DReqDepth),
++    .RspDepth   (DRspDepth),
++    .SpareReqW  (1)
++  ) u_devicefifo (
++    .clk_i,
++    .rst_ni,
++    .tl_h_i      (dreq_fifo_i),
++    .tl_h_o      (drsp_fifo_o),
++    .tl_d_o      (tl_d_o),
++    .tl_d_i      (tl_d_i),
++    .spare_req_i (1'b0),
++    .spare_req_o (),
++    .spare_rsp_i (1'b0),
++    .spare_rsp_o ()
++  );
++
++  // Request Arbiter
++  for (genvar i = 0 ; i < M ; i++) begin : gen_arbreqgnt
++    assign hrequest[i] = hreq_fifo_o[i].a_valid;
++  end
++
++  assign arb_ready = drsp_fifo_o.a_ready;
++
++  if (tlul_pkg::ArbiterImpl == "PPC") begin : gen_arb_ppc
++    prim_arbiter_ppc_surelog #(
++      .N      (M),
++      .DW     ($bits(tlul_pkg::tl_h2d_t))
++    ) u_reqarb (
++      .clk_i,
++      .rst_ni,
++      .req_i   ( hrequest    ),
++      .data_i  ( hreq_fifo_o ),
++      .gnt_o   ( hgrant      ),
++      .idx_o   (             ),
++      .valid_o ( arb_valid   ),
++      .data_o  ( arb_data    ),
++      .ready_i ( arb_ready   )
++    );
++  end else if (tlul_pkg::ArbiterImpl == "BINTREE") begin : gen_tree_arb
++    prim_arbiter_tree #(
++      .N      (M),
++      .DW     ($bits(tlul_pkg::tl_h2d_t))
++    ) u_reqarb (
++      .clk_i,
++      .rst_ni,
++      .req_i   ( hrequest    ),
++      .data_i  ( hreq_fifo_o ),
++      .gnt_o   ( hgrant      ),
++      .idx_o   (             ),
++      .valid_o ( arb_valid   ),
++      .data_o  ( arb_data    ),
++      .ready_i ( arb_ready   )
++    );
++  end else begin : gen_unknown
++    `ASSERT_INIT(UnknownArbImpl_A, 0)
++  end
++
++  logic [  M-1:0] hfifo_rspvalid;
++  logic [  M-1:0] dfifo_rspready;
++  logic [IDW-1:0] hfifo_rspid;
++  logic dfifo_rspready_merged;
++
++  // arb_data --> dreq_fifo_i
++  //   dreq_fifo_i.hd_rspready <= dfifo_rspready
++
++  assign dfifo_rspready_merged = |dfifo_rspready;
++  assign dreq_fifo_i = '{
++    a_valid:   arb_valid,
++    a_opcode:  arb_data.a_opcode,
++    a_param:   arb_data.a_param,
++    a_size:    arb_data.a_size,
++    a_source:  arb_data.a_source,
++    a_address: arb_data.a_address,
++    a_mask:    arb_data.a_mask,
++    a_data:    arb_data.a_data,
++    a_user:    arb_data.a_user,
++
++    d_ready:   dfifo_rspready_merged
++  };
++
++  // Response ID steering
++  // drsp_fifo_o --> hrsp_fifo_i[i]
++
++  // Response ID shifting before put into host fifo
++  assign hfifo_rspid = {
++    {STIDW{1'b0}},
++    drsp_fifo_o.d_source[IDW-1:STIDW]
++  };
++  for (genvar i = 0 ; i < M ; i++) begin : gen_idrouting
++    assign hfifo_rspvalid[i] = drsp_fifo_o.d_valid &
++                               (drsp_fifo_o.d_source[0+:STIDW] == i);
++    assign dfifo_rspready[i] = hreq_fifo_o[i].d_ready                &
++                               (drsp_fifo_o.d_source[0+:STIDW] == i) &
++                              drsp_fifo_o.d_valid;
++
++    assign hrsp_fifo_i[i].d_valid = hfifo_rspvalid[i];
++    assign hrsp_fifo_i[i].d_opcode = drsp_fifo_o.d_opcode;
++    assign hrsp_fifo_i[i].d_param = drsp_fifo_o.d_param;
++    assign hrsp_fifo_i[i].d_size = drsp_fifo_o.d_size;
++    assign hrsp_fifo_i[i].d_source = hfifo_rspid;
++    assign hrsp_fifo_i[i].d_sink = drsp_fifo_o.d_sink;
++    assign hrsp_fifo_i[i].d_data = drsp_fifo_o.d_data;
++    assign hrsp_fifo_i[i].d_user = drsp_fifo_o.d_user;
++    assign hrsp_fifo_i[i].d_error = drsp_fifo_o.d_error;
++    assign hrsp_fifo_i[i].a_ready = hgrant[i];
++  end
++
++  // this assertion fails when rspid[0+:STIDW] not in [0..M-1]
++  `ASSERT(rspIdInRange, drsp_fifo_o.d_valid |->
++      drsp_fifo_o.d_source[0+:STIDW] >= 0 && drsp_fifo_o.d_source[0+:STIDW] < M)
++
 +endmodule
 diff --git a/hw/ip/tlul/socket_m1.core b/hw/ip/tlul/socket_m1.core
 index 1dba035f5..b08354864 100644


### PR DESCRIPTION
This PR reverts changes from tlul_socket_m1 modules and moves them to UHDM.

Fixes: https://github.com/alainmarcel/uhdm-integration/issues/324