### PR TITLE
Move pinmux modules to uhdm

### DIFF
--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -411,6 +411,156 @@ index 052cb2f5a..b62227975 100644
  
    // Create Socket_1n
    tlul_socket_1n #(
+diff --git a/hw/ip/pinmux/rtl/pinmux.sv b/hw/ip/pinmux/rtl/pinmux.sv
+index 92da2e81c..89b58a8f7 100644
+--- a/hw/ip/pinmux/rtl/pinmux.sv
++++ b/hw/ip/pinmux/rtl/pinmux.sv
+@@ -64,8 +64,10 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+   // Regfile Breakout and Mapping //
+   //////////////////////////////////
+ 
+-  pinmux_reg2hw_t reg2hw;
+-  pinmux_hw2reg_t hw2reg;
++  //pinmux_reg2hw_t reg2hw;
++  //pinmux_hw2reg_t hw2reg;
++  wire [660:0] reg2hw;
++  wire [37:0] hw2reg;
+ 
+   pinmux_reg_top u_reg (
+     .clk_i  ,
+@@ -95,13 +97,13 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+   // 2: high-z
+   // 3: previous value
+   for (genvar k = 0; k < NMioPads; k++) begin : gen_mio_sleep
+-    assign mio_out_sleep_d[k] = (reg2hw.mio_out_sleep_val[k].q == 0) ? 1'b0 :
+-                                (reg2hw.mio_out_sleep_val[k].q == 1) ? 1'b1 :
+-                                (reg2hw.mio_out_sleep_val[k].q == 2) ? 1'b0 : mio_out_o[k];
++    assign mio_out_sleep_d[k] = (reg2hw[213 + ((k * 2) + 1)-:2] == 0) ? 1'b0 :
++                                (reg2hw[213 + ((k * 2) + 1)-:2] == 1) ? 1'b1 :
++                                (reg2hw[213 + ((k * 2) + 1)-:2] == 2) ? 1'b0 : mio_out_o[k];
+ 
+-    assign mio_oe_sleep_d[k] = (reg2hw.mio_out_sleep_val[k].q == 0) ? 1'b1 :
+-                               (reg2hw.mio_out_sleep_val[k].q == 1) ? 1'b1 :
+-                               (reg2hw.mio_out_sleep_val[k].q == 2) ? 1'b0 : mio_oe_o[k];
++    assign mio_oe_sleep_d[k] = (reg2hw[213 + ((k * 2) + 1)-:2] == 0) ? 1'b1 :
++                               (reg2hw[213 + ((k * 2) + 1)-:2] == 1) ? 1'b1 :
++                               (reg2hw[213 + ((k * 2) + 1)-:2] == 2) ? 1'b0 : mio_oe_o[k];
+   end
+ 
+   // since DIO pads are permanently mapped to a specific peripheral,
+@@ -109,10 +111,10 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+   // outputs / inouts.
+   for (genvar k = 0; k < NDioPads; k++) begin : gen_dio_sleep
+     if (DioPeriphHasSleepMode[k]) begin : gen_warl_connect
+-      assign hw2reg.dio_out_sleep_val[k].d = dio_out_sleep_val_q[k];
++      assign hw2reg[8 + ((k * 2) + 1)-:2] = dio_out_sleep_val_q[k];
+ 
+-      assign dio_out_sleep_val_d[k] = (reg2hw.dio_out_sleep_val[k].qe) ?
+-                                      reg2hw.dio_out_sleep_val[k].q :
++      assign dio_out_sleep_val_d[k] = (reg2hw[168 + (k * 3)]) ?
++                                      reg2hw[168 + ((k * 3) + 2)-:2] :
+                                       dio_out_sleep_val_q[k];
+ 
+       assign dio_out_sleep_d[k] = (dio_out_sleep_val_q[k] == 0) ? 1'b0 :
+@@ -124,7 +126,7 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+                                  (dio_out_sleep_val_q[k] == 2) ? 1'b0 : dio_oe_o[k];
+     end else begin : gen_warl_tie0
+       // these signals will be unused
+-      assign hw2reg.dio_out_sleep_val[k].d = 2'b10; // default value defined in hjson
++      assign hw2reg[8 + ((k * 2) + 1)-:2] = 2'b10; // default value defined in hjson
+       assign dio_out_sleep_val_d[k] = 2'b10; // default value defined in hjson
+       assign dio_out_sleep_d[k]     = '0;
+       assign dio_oe_sleep_d[k]      = '0;
+@@ -135,10 +137,10 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+     if (!rst_ni) begin
+       sleep_en_q          <= 1'b0;
+       dio_out_sleep_val_q <= {NDioPads{2'b10}}; // default value defined in hjson
+-      mio_out_sleep_q     <= '0;
+-      mio_oe_sleep_q      <= '0;
+-      dio_out_sleep_q     <= '0;
+-      dio_oe_sleep_q      <= '0;
++      mio_out_sleep_q <= {32 {1'b0}};
++      mio_oe_sleep_q <= {32 {1'b0}};
++      dio_out_sleep_q <= {15 {1'b0}};
++      dio_oe_sleep_q <= {15 {1'b0}};
+     end else begin
+       sleep_en_q          <= sleep_en_i;
+       dio_out_sleep_val_q <= dio_out_sleep_val_d;
+@@ -163,11 +165,11 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+   // 1. make sure mux is aligned to a power of 2 to avoid Xes.
+   logic [AlignedMuxSize-1:0] mio_data_mux;
+   // TODO: need a way to select which IO POK signal to use por pin
+-  assign mio_data_mux = AlignedMuxSize'({(&io_pok_i) ? mio_in_i : '0, 1'b1, 1'b0});
++  assign mio_data_mux = AlignedMuxSize'({(&io_pok_i) ? mio_in_i : {32 {1'b0}}, 1'b1, 1'b0});
+ 
+   for (genvar k = 0; k < NMioPeriphIn; k++) begin : gen_mio_periph_in
+     // index using configured insel
+-    assign mio_to_periph_o[k] = mio_data_mux[reg2hw.periph_insel[k].q];
++    assign mio_to_periph_o[k] = mio_data_mux[reg2hw[469 + ((k * 6) + 5)-:6]];
+   end
+ 
+   ////////////////
+@@ -184,10 +186,10 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+   for (genvar k = 0; k < NMioPads; k++) begin : gen_mio_out
+     logic sleep_en;
+     // check whether this peripheral can actually go to sleep
+-    assign sleep_en = periph_sleep_mux[reg2hw.mio_outsel[k].q] & sleep_en_q;
++    assign sleep_en = periph_sleep_mux[reg2hw[277 + ((k * 6) + 5)-:6]] & sleep_en_q;
+     // index using configured outsel
+-    assign mio_out_o[k] = (sleep_en) ? mio_out_sleep_q[k] : periph_data_mux[reg2hw.mio_outsel[k].q];
+-    assign mio_oe_o[k]  = (sleep_en) ? mio_oe_sleep_q[k]  : periph_oe_mux[reg2hw.mio_outsel[k].q];
++    assign mio_out_o[k] = (sleep_en) ? mio_out_sleep_q[k] : periph_data_mux[reg2hw[277 + ((k * 6) + 5)-:6]];
++    assign mio_oe_o[k]  = (sleep_en) ? mio_oe_sleep_q[k]  : periph_oe_mux[reg2hw[277 + ((k * 6) + 5)-:6]];
+   end
+ 
+   /////////////////////
+@@ -231,9 +233,9 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+ 
+   for (genvar k = 0; k < NWkupDetect; k++) begin : gen_wkup_detect
+     logic pin_value;
+-    assign pin_value = (reg2hw.wkup_detector[k].miodio.q)           ?
+-                       dio_data_mux[reg2hw.wkup_detector_padsel[k]] :
+-                       mio_data_mux[reg2hw.wkup_detector_padsel[k]];
++    assign pin_value = (reg2hw[120 + (k * 5)])           ?
++                       dio_data_mux[reg2hw[16 + (k * 5)+:5]] :
++                       mio_data_mux[reg2hw[16 + (k * 5)+:5]];
+ 
+     pinmux_wkup i_pinmux_wkup (
+       .clk_i,
+@@ -241,15 +243,15 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+       .clk_aon_i,
+       .rst_aon_ni,
+       // config signals. these are synched to clk_aon internally
+-      .wkup_en_i          ( reg2hw.wkup_detector_en[k].q                ),
+-      .filter_en_i        ( reg2hw.wkup_detector[k].filter.q            ),
+-      .wkup_mode_i        ( wkup_mode_e'(reg2hw.wkup_detector[k].mode.q)),
+-      .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q            ),
++      .wkup_en_i          ( reg2hw[160 + k]                ),
++      .filter_en_i        ( reg2hw[120 + ((k * 5) + 1)]            ),
++      .wkup_mode_i        ( wkup_mode_e'(reg2hw[120 + ((k * 5) + 4)-:3])),
++      .wkup_cnt_th_i      ( reg2hw[56 + ((k * 8) + 7)-:8]            ),
+       .pin_value_i        ( pin_value                                   ),
+       // cause reg signals. these are synched from/to clk_aon internally
+-      .wkup_cause_valid_i ( reg2hw.wkup_cause[k].qe                     ),
+-      .wkup_cause_data_i  ( reg2hw.wkup_cause[k].q                      ),
+-      .wkup_cause_data_o  ( hw2reg.wkup_cause[k].d                      ),
++      .wkup_cause_valid_i ( reg2hw[k * 2]                     ),
++      .wkup_cause_data_i  ( reg2hw[(k * 2) + 1]                      ),
++      .wkup_cause_data_o  ( hw2reg[k]                      ),
+       // wakeup request signals on clk_aon (level encoded)
+       .aon_wkup_req_o     ( aon_wkup_req[k]                             )
+     );
+@@ -288,8 +290,8 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
+ 
+   always_ff @(posedge clk_i or negedge rst_ni) begin : p_strap_sample
+     if (!rst_ni) begin
+-      lc_strap_q       <= '0;
+-      dft_strap_test_q <= '0;
++      lc_strap_q       <= {3{1'b0}};
++      dft_strap_test_q <= {3{1'b0}};
+     end else begin
+       lc_strap_q       <= lc_strap_d;
+       dft_strap_test_q <= dft_strap_test_d;
 diff --git a/hw/ip/pinmux/rtl/pinmux_wkup.sv b/hw/ip/pinmux/rtl/pinmux_wkup.sv
 index 101062346..2eb8496b3 100644
 --- a/hw/ip/pinmux/rtl/pinmux_wkup.sv
@@ -1642,6 +1792,6710 @@ index 9889b0a1f..9b297e67f 100644
    always_ff @(posedge clk_i or negedge rst_ni) begin
      if (!rst_ni) begin
        d_sync_q <= '0;
+diff --git a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+index bf3bc9fc3..88828411c 100644
+--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
++++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+@@ -14,8 +14,10 @@ module pinmux_reg_top (
+   input  tlul_pkg::tl_h2d_t tl_i,
+   output tlul_pkg::tl_d2h_t tl_o,
+   // To HW
+-  output pinmux_reg_pkg::pinmux_reg2hw_t reg2hw, // Write
+-  input  pinmux_reg_pkg::pinmux_hw2reg_t hw2reg, // Read
++  //output pinmux_reg_pkg::pinmux_reg2hw_t reg2hw, // Write
++  //input  pinmux_reg_pkg::pinmux_hw2reg_t hw2reg, // Read
++  output wire [660:0] reg2hw,
++  input wire [37:0] hw2reg,
+ 
+   // Config
+   input devmode_i // If 1, explicit error return for unmapped register access
+@@ -598,4263 +600,2417 @@ module pinmux_reg_top (
+   logic wkup_cause_cause7_wd;
+   logic wkup_cause_cause7_we;
+   logic wkup_cause_cause7_re;
+-
+-  // Register instances
+-  // R[regen]: V(False)
+-
+   prim_subreg #(
+-    .DW      (1),
++    .DW(1),
+     .SWACCESS("W0C"),
+-    .RESVAL  (1'h1)
+-  ) u_regen (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (regen_we),
+-    .wd     (regen_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (regen_qs)
+-  );
+-
+-
+-
+-  // Subregister 0 of Multireg periph_insel
+-  // R[periph_insel0]: V(False)
+-
+-  // F[in0]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel0_in0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel0_in0_we & regen_qs),
+-    .wd     (periph_insel0_in0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel0_in0_qs)
+-  );
+-
+-
+-  // F[in1]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel0_in1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel0_in1_we & regen_qs),
+-    .wd     (periph_insel0_in1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel0_in1_qs)
+-  );
+-
+-
+-  // F[in2]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel0_in2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel0_in2_we & regen_qs),
+-    .wd     (periph_insel0_in2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel0_in2_qs)
+-  );
+-
+-
+-  // F[in3]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel0_in3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel0_in3_we & regen_qs),
+-    .wd     (periph_insel0_in3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel0_in3_qs)
+-  );
+-
+-
+-  // F[in4]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel0_in4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel0_in4_we & regen_qs),
+-    .wd     (periph_insel0_in4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel0_in4_qs)
+-  );
+-
+-
+-  // Subregister 5 of Multireg periph_insel
+-  // R[periph_insel1]: V(False)
+-
+-  // F[in5]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel1_in5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel1_in5_we & regen_qs),
+-    .wd     (periph_insel1_in5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel1_in5_qs)
+-  );
+-
+-
+-  // F[in6]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel1_in6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel1_in6_we & regen_qs),
+-    .wd     (periph_insel1_in6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel1_in6_qs)
+-  );
+-
+-
+-  // F[in7]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel1_in7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel1_in7_we & regen_qs),
+-    .wd     (periph_insel1_in7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel1_in7_qs)
+-  );
+-
+-
+-  // F[in8]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel1_in8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel1_in8_we & regen_qs),
+-    .wd     (periph_insel1_in8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel1_in8_qs)
+-  );
+-
+-
+-  // F[in9]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel1_in9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel1_in9_we & regen_qs),
+-    .wd     (periph_insel1_in9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel1_in9_qs)
+-  );
+-
+-
+-  // Subregister 10 of Multireg periph_insel
+-  // R[periph_insel2]: V(False)
+-
+-  // F[in10]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel2_in10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel2_in10_we & regen_qs),
+-    .wd     (periph_insel2_in10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel2_in10_qs)
+-  );
+-
+-
+-  // F[in11]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel2_in11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel2_in11_we & regen_qs),
+-    .wd     (periph_insel2_in11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel2_in11_qs)
+-  );
+-
+-
+-  // F[in12]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel2_in12 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel2_in12_we & regen_qs),
+-    .wd     (periph_insel2_in12_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[12].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel2_in12_qs)
+-  );
+-
+-
+-  // F[in13]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel2_in13 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel2_in13_we & regen_qs),
+-    .wd     (periph_insel2_in13_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[13].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel2_in13_qs)
+-  );
+-
+-
+-  // F[in14]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel2_in14 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel2_in14_we & regen_qs),
+-    .wd     (periph_insel2_in14_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[14].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel2_in14_qs)
+-  );
+-
+-
+-  // Subregister 15 of Multireg periph_insel
+-  // R[periph_insel3]: V(False)
+-
+-  // F[in15]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel3_in15 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel3_in15_we & regen_qs),
+-    .wd     (periph_insel3_in15_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[15].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel3_in15_qs)
+-  );
+-
+-
+-  // F[in16]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel3_in16 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel3_in16_we & regen_qs),
+-    .wd     (periph_insel3_in16_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[16].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel3_in16_qs)
+-  );
+-
+-
+-  // F[in17]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel3_in17 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel3_in17_we & regen_qs),
+-    .wd     (periph_insel3_in17_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[17].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel3_in17_qs)
+-  );
+-
+-
+-  // F[in18]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel3_in18 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel3_in18_we & regen_qs),
+-    .wd     (periph_insel3_in18_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[18].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel3_in18_qs)
+-  );
+-
+-
+-  // F[in19]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel3_in19 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel3_in19_we & regen_qs),
+-    .wd     (periph_insel3_in19_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[19].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel3_in19_qs)
+-  );
+-
+-
+-  // Subregister 20 of Multireg periph_insel
+-  // R[periph_insel4]: V(False)
+-
+-  // F[in20]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel4_in20 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel4_in20_we & regen_qs),
+-    .wd     (periph_insel4_in20_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[20].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel4_in20_qs)
+-  );
+-
+-
+-  // F[in21]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel4_in21 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel4_in21_we & regen_qs),
+-    .wd     (periph_insel4_in21_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[21].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel4_in21_qs)
+-  );
+-
+-
+-  // F[in22]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel4_in22 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel4_in22_we & regen_qs),
+-    .wd     (periph_insel4_in22_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[22].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel4_in22_qs)
+-  );
+-
+-
+-  // F[in23]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel4_in23 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel4_in23_we & regen_qs),
+-    .wd     (periph_insel4_in23_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[23].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel4_in23_qs)
+-  );
+-
+-
+-  // F[in24]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel4_in24 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel4_in24_we & regen_qs),
+-    .wd     (periph_insel4_in24_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[24].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel4_in24_qs)
+-  );
+-
+-
+-  // Subregister 25 of Multireg periph_insel
+-  // R[periph_insel5]: V(False)
+-
+-  // F[in25]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel5_in25 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel5_in25_we & regen_qs),
+-    .wd     (periph_insel5_in25_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[25].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel5_in25_qs)
++    .RESVAL(1'h1)
++  ) u_regen(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(regen_we),
++    .wd(regen_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(),
++    .qs(regen_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel0_in0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel0_in0_we & regen_qs),
++    .wd(periph_insel0_in0_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[474-:6]),
++    .qs(periph_insel0_in0_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel0_in1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel0_in1_we & regen_qs),
++    .wd(periph_insel0_in1_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[480-:6]),
++    .qs(periph_insel0_in1_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel0_in2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel0_in2_we & regen_qs),
++    .wd(periph_insel0_in2_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[486-:6]),
++    .qs(periph_insel0_in2_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel0_in3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel0_in3_we & regen_qs),
++    .wd(periph_insel0_in3_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[492-:6]),
++    .qs(periph_insel0_in3_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel0_in4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel0_in4_we & regen_qs),
++    .wd(periph_insel0_in4_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[498-:6]),
++    .qs(periph_insel0_in4_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel1_in5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel1_in5_we & regen_qs),
++    .wd(periph_insel1_in5_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[504-:6]),
++    .qs(periph_insel1_in5_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel1_in6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel1_in6_we & regen_qs),
++    .wd(periph_insel1_in6_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[510-:6]),
++    .qs(periph_insel1_in6_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel1_in7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel1_in7_we & regen_qs),
++    .wd(periph_insel1_in7_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[516-:6]),
++    .qs(periph_insel1_in7_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel1_in8(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel1_in8_we & regen_qs),
++    .wd(periph_insel1_in8_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[522-:6]),
++    .qs(periph_insel1_in8_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel1_in9(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel1_in9_we & regen_qs),
++    .wd(periph_insel1_in9_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[528-:6]),
++    .qs(periph_insel1_in9_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel2_in10(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel2_in10_we & regen_qs),
++    .wd(periph_insel2_in10_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[534-:6]),
++    .qs(periph_insel2_in10_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel2_in11(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel2_in11_we & regen_qs),
++    .wd(periph_insel2_in11_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[540-:6]),
++    .qs(periph_insel2_in11_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel2_in12(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel2_in12_we & regen_qs),
++    .wd(periph_insel2_in12_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[546-:6]),
++    .qs(periph_insel2_in12_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel2_in13(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel2_in13_we & regen_qs),
++    .wd(periph_insel2_in13_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[552-:6]),
++    .qs(periph_insel2_in13_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel2_in14(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel2_in14_we & regen_qs),
++    .wd(periph_insel2_in14_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[558-:6]),
++    .qs(periph_insel2_in14_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel3_in15(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel3_in15_we & regen_qs),
++    .wd(periph_insel3_in15_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[564-:6]),
++    .qs(periph_insel3_in15_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel3_in16(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel3_in16_we & regen_qs),
++    .wd(periph_insel3_in16_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[570-:6]),
++    .qs(periph_insel3_in16_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel3_in17(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel3_in17_we & regen_qs),
++    .wd(periph_insel3_in17_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[576-:6]),
++    .qs(periph_insel3_in17_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel3_in18(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel3_in18_we & regen_qs),
++    .wd(periph_insel3_in18_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[582-:6]),
++    .qs(periph_insel3_in18_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel3_in19(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel3_in19_we & regen_qs),
++    .wd(periph_insel3_in19_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[588-:6]),
++    .qs(periph_insel3_in19_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel4_in20(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel4_in20_we & regen_qs),
++    .wd(periph_insel4_in20_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[594-:6]),
++    .qs(periph_insel4_in20_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel4_in21(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel4_in21_we & regen_qs),
++    .wd(periph_insel4_in21_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[600-:6]),
++    .qs(periph_insel4_in21_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel4_in22(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel4_in22_we & regen_qs),
++    .wd(periph_insel4_in22_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[606-:6]),
++    .qs(periph_insel4_in22_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel4_in23(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel4_in23_we & regen_qs),
++    .wd(periph_insel4_in23_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[612-:6]),
++    .qs(periph_insel4_in23_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel4_in24(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel4_in24_we & regen_qs),
++    .wd(periph_insel4_in24_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[618-:6]),
++    .qs(periph_insel4_in24_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel5_in25(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel5_in25_we & regen_qs),
++    .wd(periph_insel5_in25_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[624-:6]),
++    .qs(periph_insel5_in25_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel5_in26(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel5_in26_we & regen_qs),
++    .wd(periph_insel5_in26_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[630-:6]),
++    .qs(periph_insel5_in26_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel5_in27(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel5_in27_we & regen_qs),
++    .wd(periph_insel5_in27_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[636-:6]),
++    .qs(periph_insel5_in27_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel5_in28(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel5_in28_we & regen_qs),
++    .wd(periph_insel5_in28_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[642-:6]),
++    .qs(periph_insel5_in28_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel5_in29(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel5_in29_we & regen_qs),
++    .wd(periph_insel5_in29_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[648-:6]),
++    .qs(periph_insel5_in29_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel6_in30(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel6_in30_we & regen_qs),
++    .wd(periph_insel6_in30_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[654-:6]),
++    .qs(periph_insel6_in30_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h00)
++  ) u_periph_insel6_in31(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(periph_insel6_in31_we & regen_qs),
++    .wd(periph_insel6_in31_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[660-:6]),
++    .qs(periph_insel6_in31_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel0_out0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel0_out0_we & regen_qs),
++    .wd(mio_outsel0_out0_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[282-:6]),
++    .qs(mio_outsel0_out0_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel0_out1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel0_out1_we & regen_qs),
++    .wd(mio_outsel0_out1_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[288-:6]),
++    .qs(mio_outsel0_out1_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel0_out2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel0_out2_we & regen_qs),
++    .wd(mio_outsel0_out2_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[294-:6]),
++    .qs(mio_outsel0_out2_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel0_out3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel0_out3_we & regen_qs),
++    .wd(mio_outsel0_out3_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[300-:6]),
++    .qs(mio_outsel0_out3_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel0_out4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel0_out4_we & regen_qs),
++    .wd(mio_outsel0_out4_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[306-:6]),
++    .qs(mio_outsel0_out4_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel1_out5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel1_out5_we & regen_qs),
++    .wd(mio_outsel1_out5_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[312-:6]),
++    .qs(mio_outsel1_out5_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel1_out6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel1_out6_we & regen_qs),
++    .wd(mio_outsel1_out6_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[318-:6]),
++    .qs(mio_outsel1_out6_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel1_out7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel1_out7_we & regen_qs),
++    .wd(mio_outsel1_out7_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[324-:6]),
++    .qs(mio_outsel1_out7_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel1_out8(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel1_out8_we & regen_qs),
++    .wd(mio_outsel1_out8_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[330-:6]),
++    .qs(mio_outsel1_out8_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel1_out9(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel1_out9_we & regen_qs),
++    .wd(mio_outsel1_out9_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[336-:6]),
++    .qs(mio_outsel1_out9_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel2_out10(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel2_out10_we & regen_qs),
++    .wd(mio_outsel2_out10_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[342-:6]),
++    .qs(mio_outsel2_out10_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel2_out11(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel2_out11_we & regen_qs),
++    .wd(mio_outsel2_out11_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[348-:6]),
++    .qs(mio_outsel2_out11_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel2_out12(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel2_out12_we & regen_qs),
++    .wd(mio_outsel2_out12_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[354-:6]),
++    .qs(mio_outsel2_out12_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel2_out13(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel2_out13_we & regen_qs),
++    .wd(mio_outsel2_out13_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[360-:6]),
++    .qs(mio_outsel2_out13_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel2_out14(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel2_out14_we & regen_qs),
++    .wd(mio_outsel2_out14_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[366-:6]),
++    .qs(mio_outsel2_out14_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel3_out15(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel3_out15_we & regen_qs),
++    .wd(mio_outsel3_out15_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[372-:6]),
++    .qs(mio_outsel3_out15_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel3_out16(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel3_out16_we & regen_qs),
++    .wd(mio_outsel3_out16_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[378-:6]),
++    .qs(mio_outsel3_out16_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel3_out17(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel3_out17_we & regen_qs),
++    .wd(mio_outsel3_out17_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[384-:6]),
++    .qs(mio_outsel3_out17_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel3_out18(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel3_out18_we & regen_qs),
++    .wd(mio_outsel3_out18_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[390-:6]),
++    .qs(mio_outsel3_out18_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel3_out19(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel3_out19_we & regen_qs),
++    .wd(mio_outsel3_out19_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[396-:6]),
++    .qs(mio_outsel3_out19_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel4_out20(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel4_out20_we & regen_qs),
++    .wd(mio_outsel4_out20_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[402-:6]),
++    .qs(mio_outsel4_out20_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel4_out21(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel4_out21_we & regen_qs),
++    .wd(mio_outsel4_out21_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[408-:6]),
++    .qs(mio_outsel4_out21_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel4_out22(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel4_out22_we & regen_qs),
++    .wd(mio_outsel4_out22_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[414-:6]),
++    .qs(mio_outsel4_out22_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel4_out23(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel4_out23_we & regen_qs),
++    .wd(mio_outsel4_out23_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[420-:6]),
++    .qs(mio_outsel4_out23_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel4_out24(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel4_out24_we & regen_qs),
++    .wd(mio_outsel4_out24_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[426-:6]),
++    .qs(mio_outsel4_out24_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel5_out25(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel5_out25_we & regen_qs),
++    .wd(mio_outsel5_out25_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[432-:6]),
++    .qs(mio_outsel5_out25_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel5_out26(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel5_out26_we & regen_qs),
++    .wd(mio_outsel5_out26_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[438-:6]),
++    .qs(mio_outsel5_out26_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel5_out27(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel5_out27_we & regen_qs),
++    .wd(mio_outsel5_out27_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[444-:6]),
++    .qs(mio_outsel5_out27_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel5_out28(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel5_out28_we & regen_qs),
++    .wd(mio_outsel5_out28_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[450-:6]),
++    .qs(mio_outsel5_out28_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel5_out29(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel5_out29_we & regen_qs),
++    .wd(mio_outsel5_out29_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[456-:6]),
++    .qs(mio_outsel5_out29_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel6_out30(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel6_out30_we & regen_qs),
++    .wd(mio_outsel6_out30_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[462-:6]),
++    .qs(mio_outsel6_out30_qs)
++  );
++  prim_subreg #(
++    .DW(6),
++    .SWACCESS("RW"),
++    .RESVAL(6'h02)
++  ) u_mio_outsel6_out31(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_outsel6_out31_we & regen_qs),
++    .wd(mio_outsel6_out31_wd),
++    .de(1'b0),
++    .d({6 {1'b0}}),
++    .qe(),
++    .q(reg2hw[468-:6]),
++    .qs(mio_outsel6_out31_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out0_we & regen_qs),
++    .wd(mio_out_sleep_val0_out0_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[214-:2]),
++    .qs(mio_out_sleep_val0_out0_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out1_we & regen_qs),
++    .wd(mio_out_sleep_val0_out1_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[216-:2]),
++    .qs(mio_out_sleep_val0_out1_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out2_we & regen_qs),
++    .wd(mio_out_sleep_val0_out2_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[218-:2]),
++    .qs(mio_out_sleep_val0_out2_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out3_we & regen_qs),
++    .wd(mio_out_sleep_val0_out3_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[220-:2]),
++    .qs(mio_out_sleep_val0_out3_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out4_we & regen_qs),
++    .wd(mio_out_sleep_val0_out4_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[222-:2]),
++    .qs(mio_out_sleep_val0_out4_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out5_we & regen_qs),
++    .wd(mio_out_sleep_val0_out5_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[224-:2]),
++    .qs(mio_out_sleep_val0_out5_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out6_we & regen_qs),
++    .wd(mio_out_sleep_val0_out6_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[226-:2]),
++    .qs(mio_out_sleep_val0_out6_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out7_we & regen_qs),
++    .wd(mio_out_sleep_val0_out7_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[228-:2]),
++    .qs(mio_out_sleep_val0_out7_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out8(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out8_we & regen_qs),
++    .wd(mio_out_sleep_val0_out8_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[230-:2]),
++    .qs(mio_out_sleep_val0_out8_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out9(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out9_we & regen_qs),
++    .wd(mio_out_sleep_val0_out9_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[232-:2]),
++    .qs(mio_out_sleep_val0_out9_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out10(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out10_we & regen_qs),
++    .wd(mio_out_sleep_val0_out10_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[234-:2]),
++    .qs(mio_out_sleep_val0_out10_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out11(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out11_we & regen_qs),
++    .wd(mio_out_sleep_val0_out11_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[236-:2]),
++    .qs(mio_out_sleep_val0_out11_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out12(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out12_we & regen_qs),
++    .wd(mio_out_sleep_val0_out12_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[238-:2]),
++    .qs(mio_out_sleep_val0_out12_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out13(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out13_we & regen_qs),
++    .wd(mio_out_sleep_val0_out13_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[240-:2]),
++    .qs(mio_out_sleep_val0_out13_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out14(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out14_we & regen_qs),
++    .wd(mio_out_sleep_val0_out14_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[242-:2]),
++    .qs(mio_out_sleep_val0_out14_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val0_out15(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val0_out15_we & regen_qs),
++    .wd(mio_out_sleep_val0_out15_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[244-:2]),
++    .qs(mio_out_sleep_val0_out15_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out16(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out16_we & regen_qs),
++    .wd(mio_out_sleep_val1_out16_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[246-:2]),
++    .qs(mio_out_sleep_val1_out16_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out17(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out17_we & regen_qs),
++    .wd(mio_out_sleep_val1_out17_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[248-:2]),
++    .qs(mio_out_sleep_val1_out17_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out18(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out18_we & regen_qs),
++    .wd(mio_out_sleep_val1_out18_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[250-:2]),
++    .qs(mio_out_sleep_val1_out18_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out19(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out19_we & regen_qs),
++    .wd(mio_out_sleep_val1_out19_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[252-:2]),
++    .qs(mio_out_sleep_val1_out19_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out20(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out20_we & regen_qs),
++    .wd(mio_out_sleep_val1_out20_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[254-:2]),
++    .qs(mio_out_sleep_val1_out20_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out21(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out21_we & regen_qs),
++    .wd(mio_out_sleep_val1_out21_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[256-:2]),
++    .qs(mio_out_sleep_val1_out21_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out22(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out22_we & regen_qs),
++    .wd(mio_out_sleep_val1_out22_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[258-:2]),
++    .qs(mio_out_sleep_val1_out22_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out23(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out23_we & regen_qs),
++    .wd(mio_out_sleep_val1_out23_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[260-:2]),
++    .qs(mio_out_sleep_val1_out23_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out24(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out24_we & regen_qs),
++    .wd(mio_out_sleep_val1_out24_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[262-:2]),
++    .qs(mio_out_sleep_val1_out24_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out25(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out25_we & regen_qs),
++    .wd(mio_out_sleep_val1_out25_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[264-:2]),
++    .qs(mio_out_sleep_val1_out25_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out26(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out26_we & regen_qs),
++    .wd(mio_out_sleep_val1_out26_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[266-:2]),
++    .qs(mio_out_sleep_val1_out26_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out27(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out27_we & regen_qs),
++    .wd(mio_out_sleep_val1_out27_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[268-:2]),
++    .qs(mio_out_sleep_val1_out27_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out28(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out28_we & regen_qs),
++    .wd(mio_out_sleep_val1_out28_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[270-:2]),
++    .qs(mio_out_sleep_val1_out28_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out29(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out29_we & regen_qs),
++    .wd(mio_out_sleep_val1_out29_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[272-:2]),
++    .qs(mio_out_sleep_val1_out29_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out30(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out30_we & regen_qs),
++    .wd(mio_out_sleep_val1_out30_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[274-:2]),
++    .qs(mio_out_sleep_val1_out30_qs)
++  );
++  prim_subreg #(
++    .DW(2),
++    .SWACCESS("RW"),
++    .RESVAL(2'h2)
++  ) u_mio_out_sleep_val1_out31(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(mio_out_sleep_val1_out31_we & regen_qs),
++    .wd(mio_out_sleep_val1_out31_wd),
++    .de(1'b0),
++    .d({2 {1'b0}}),
++    .qe(),
++    .q(reg2hw[276-:2]),
++    .qs(mio_out_sleep_val1_out31_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out0(
++    .re(dio_out_sleep_val_out0_re),
++    .we(dio_out_sleep_val_out0_we & regen_qs),
++    .wd(dio_out_sleep_val_out0_wd),
++    .d(hw2reg[9-:2]),
++    .qre(),
++    .qe(reg2hw[168]),
++    .q(reg2hw[170-:2]),
++    .qs(dio_out_sleep_val_out0_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out1(
++    .re(dio_out_sleep_val_out1_re),
++    .we(dio_out_sleep_val_out1_we & regen_qs),
++    .wd(dio_out_sleep_val_out1_wd),
++    .d(hw2reg[11-:2]),
++    .qre(),
++    .qe(reg2hw[171]),
++    .q(reg2hw[173-:2]),
++    .qs(dio_out_sleep_val_out1_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out2(
++    .re(dio_out_sleep_val_out2_re),
++    .we(dio_out_sleep_val_out2_we & regen_qs),
++    .wd(dio_out_sleep_val_out2_wd),
++    .d(hw2reg[13-:2]),
++    .qre(),
++    .qe(reg2hw[174]),
++    .q(reg2hw[176-:2]),
++    .qs(dio_out_sleep_val_out2_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out3(
++    .re(dio_out_sleep_val_out3_re),
++    .we(dio_out_sleep_val_out3_we & regen_qs),
++    .wd(dio_out_sleep_val_out3_wd),
++    .d(hw2reg[15-:2]),
++    .qre(),
++    .qe(reg2hw[177]),
++    .q(reg2hw[179-:2]),
++    .qs(dio_out_sleep_val_out3_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out4(
++    .re(dio_out_sleep_val_out4_re),
++    .we(dio_out_sleep_val_out4_we & regen_qs),
++    .wd(dio_out_sleep_val_out4_wd),
++    .d(hw2reg[17-:2]),
++    .qre(),
++    .qe(reg2hw[180]),
++    .q(reg2hw[182-:2]),
++    .qs(dio_out_sleep_val_out4_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out5(
++    .re(dio_out_sleep_val_out5_re),
++    .we(dio_out_sleep_val_out5_we & regen_qs),
++    .wd(dio_out_sleep_val_out5_wd),
++    .d(hw2reg[19-:2]),
++    .qre(),
++    .qe(reg2hw[183]),
++    .q(reg2hw[185-:2]),
++    .qs(dio_out_sleep_val_out5_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out6(
++    .re(dio_out_sleep_val_out6_re),
++    .we(dio_out_sleep_val_out6_we & regen_qs),
++    .wd(dio_out_sleep_val_out6_wd),
++    .d(hw2reg[21-:2]),
++    .qre(),
++    .qe(reg2hw[186]),
++    .q(reg2hw[188-:2]),
++    .qs(dio_out_sleep_val_out6_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out7(
++    .re(dio_out_sleep_val_out7_re),
++    .we(dio_out_sleep_val_out7_we & regen_qs),
++    .wd(dio_out_sleep_val_out7_wd),
++    .d(hw2reg[23-:2]),
++    .qre(),
++    .qe(reg2hw[189]),
++    .q(reg2hw[191-:2]),
++    .qs(dio_out_sleep_val_out7_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out8(
++    .re(dio_out_sleep_val_out8_re),
++    .we(dio_out_sleep_val_out8_we & regen_qs),
++    .wd(dio_out_sleep_val_out8_wd),
++    .d(hw2reg[25-:2]),
++    .qre(),
++    .qe(reg2hw[192]),
++    .q(reg2hw[194-:2]),
++    .qs(dio_out_sleep_val_out8_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out9(
++    .re(dio_out_sleep_val_out9_re),
++    .we(dio_out_sleep_val_out9_we & regen_qs),
++    .wd(dio_out_sleep_val_out9_wd),
++    .d(hw2reg[27-:2]),
++    .qre(),
++    .qe(reg2hw[195]),
++    .q(reg2hw[197-:2]),
++    .qs(dio_out_sleep_val_out9_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out10(
++    .re(dio_out_sleep_val_out10_re),
++    .we(dio_out_sleep_val_out10_we & regen_qs),
++    .wd(dio_out_sleep_val_out10_wd),
++    .d(hw2reg[29-:2]),
++    .qre(),
++    .qe(reg2hw[198]),
++    .q(reg2hw[200-:2]),
++    .qs(dio_out_sleep_val_out10_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out11(
++    .re(dio_out_sleep_val_out11_re),
++    .we(dio_out_sleep_val_out11_we & regen_qs),
++    .wd(dio_out_sleep_val_out11_wd),
++    .d(hw2reg[31-:2]),
++    .qre(),
++    .qe(reg2hw[201]),
++    .q(reg2hw[203-:2]),
++    .qs(dio_out_sleep_val_out11_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out12(
++    .re(dio_out_sleep_val_out12_re),
++    .we(dio_out_sleep_val_out12_we & regen_qs),
++    .wd(dio_out_sleep_val_out12_wd),
++    .d(hw2reg[33-:2]),
++    .qre(),
++    .qe(reg2hw[204]),
++    .q(reg2hw[206-:2]),
++    .qs(dio_out_sleep_val_out12_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out13(
++    .re(dio_out_sleep_val_out13_re),
++    .we(dio_out_sleep_val_out13_we & regen_qs),
++    .wd(dio_out_sleep_val_out13_wd),
++    .d(hw2reg[35-:2]),
++    .qre(),
++    .qe(reg2hw[207]),
++    .q(reg2hw[209-:2]),
++    .qs(dio_out_sleep_val_out13_qs)
++  );
++  prim_subreg_ext #(.DW(2)) u_dio_out_sleep_val_out14(
++    .re(dio_out_sleep_val_out14_re),
++    .we(dio_out_sleep_val_out14_we & regen_qs),
++    .wd(dio_out_sleep_val_out14_wd),
++    .d(hw2reg[37-:2]),
++    .qre(),
++    .qe(reg2hw[210]),
++    .q(reg2hw[212-:2]),
++    .qs(dio_out_sleep_val_out14_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en0_we & regen_qs),
++    .wd(wkup_detector_en_en0_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[160]),
++    .qs(wkup_detector_en_en0_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en1_we & regen_qs),
++    .wd(wkup_detector_en_en1_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[161]),
++    .qs(wkup_detector_en_en1_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en2_we & regen_qs),
++    .wd(wkup_detector_en_en2_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[162]),
++    .qs(wkup_detector_en_en2_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en3_we & regen_qs),
++    .wd(wkup_detector_en_en3_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[163]),
++    .qs(wkup_detector_en_en3_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en4_we & regen_qs),
++    .wd(wkup_detector_en_en4_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[164]),
++    .qs(wkup_detector_en_en4_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en5_we & regen_qs),
++    .wd(wkup_detector_en_en5_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[165]),
++    .qs(wkup_detector_en_en5_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en6_we & regen_qs),
++    .wd(wkup_detector_en_en6_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[166]),
++    .qs(wkup_detector_en_en6_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector_en_en7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_en_en7_we & regen_qs),
++    .wd(wkup_detector_en_en7_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[167]),
++    .qs(wkup_detector_en_en7_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector0_mode0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector0_mode0_we & regen_qs),
++    .wd(wkup_detector0_mode0_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[124-:3]),
++    .qs(wkup_detector0_mode0_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector0_filter0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector0_filter0_we & regen_qs),
++    .wd(wkup_detector0_filter0_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[121]),
++    .qs(wkup_detector0_filter0_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector0_miodio0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector0_miodio0_we & regen_qs),
++    .wd(wkup_detector0_miodio0_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[120]),
++    .qs(wkup_detector0_miodio0_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector1_mode1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector1_mode1_we & regen_qs),
++    .wd(wkup_detector1_mode1_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[129-:3]),
++    .qs(wkup_detector1_mode1_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector1_filter1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector1_filter1_we & regen_qs),
++    .wd(wkup_detector1_filter1_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[126]),
++    .qs(wkup_detector1_filter1_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector1_miodio1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector1_miodio1_we & regen_qs),
++    .wd(wkup_detector1_miodio1_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[125]),
++    .qs(wkup_detector1_miodio1_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector2_mode2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector2_mode2_we & regen_qs),
++    .wd(wkup_detector2_mode2_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[134-:3]),
++    .qs(wkup_detector2_mode2_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector2_filter2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector2_filter2_we & regen_qs),
++    .wd(wkup_detector2_filter2_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[131]),
++    .qs(wkup_detector2_filter2_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector2_miodio2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector2_miodio2_we & regen_qs),
++    .wd(wkup_detector2_miodio2_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[130]),
++    .qs(wkup_detector2_miodio2_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector3_mode3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector3_mode3_we & regen_qs),
++    .wd(wkup_detector3_mode3_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[139-:3]),
++    .qs(wkup_detector3_mode3_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector3_filter3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector3_filter3_we & regen_qs),
++    .wd(wkup_detector3_filter3_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[136]),
++    .qs(wkup_detector3_filter3_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector3_miodio3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector3_miodio3_we & regen_qs),
++    .wd(wkup_detector3_miodio3_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[135]),
++    .qs(wkup_detector3_miodio3_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector4_mode4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector4_mode4_we & regen_qs),
++    .wd(wkup_detector4_mode4_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[144-:3]),
++    .qs(wkup_detector4_mode4_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector4_filter4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector4_filter4_we & regen_qs),
++    .wd(wkup_detector4_filter4_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[141]),
++    .qs(wkup_detector4_filter4_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector4_miodio4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector4_miodio4_we & regen_qs),
++    .wd(wkup_detector4_miodio4_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[140]),
++    .qs(wkup_detector4_miodio4_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector5_mode5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector5_mode5_we & regen_qs),
++    .wd(wkup_detector5_mode5_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[149-:3]),
++    .qs(wkup_detector5_mode5_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector5_filter5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector5_filter5_we & regen_qs),
++    .wd(wkup_detector5_filter5_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[146]),
++    .qs(wkup_detector5_filter5_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector5_miodio5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector5_miodio5_we & regen_qs),
++    .wd(wkup_detector5_miodio5_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[145]),
++    .qs(wkup_detector5_miodio5_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector6_mode6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector6_mode6_we & regen_qs),
++    .wd(wkup_detector6_mode6_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[154-:3]),
++    .qs(wkup_detector6_mode6_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector6_filter6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector6_filter6_we & regen_qs),
++    .wd(wkup_detector6_filter6_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[151]),
++    .qs(wkup_detector6_filter6_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector6_miodio6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector6_miodio6_we & regen_qs),
++    .wd(wkup_detector6_miodio6_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[150]),
++    .qs(wkup_detector6_miodio6_qs)
++  );
++  prim_subreg #(
++    .DW(3),
++    .SWACCESS("RW"),
++    .RESVAL(3'h0)
++  ) u_wkup_detector7_mode7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector7_mode7_we & regen_qs),
++    .wd(wkup_detector7_mode7_wd),
++    .de(1'b0),
++    .d({3 {1'b0}}),
++    .qe(),
++    .q(reg2hw[159-:3]),
++    .qs(wkup_detector7_mode7_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector7_filter7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector7_filter7_we & regen_qs),
++    .wd(wkup_detector7_filter7_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[156]),
++    .qs(wkup_detector7_filter7_qs)
++  );
++  prim_subreg #(
++    .DW(1),
++    .SWACCESS("RW"),
++    .RESVAL(1'h0)
++  ) u_wkup_detector7_miodio7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector7_miodio7_we & regen_qs),
++    .wd(wkup_detector7_miodio7_wd),
++    .de(1'b0),
++    .d(1'b0),
++    .qe(),
++    .q(reg2hw[155]),
++    .qs(wkup_detector7_miodio7_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th0_th0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th0_th0_we & regen_qs),
++    .wd(wkup_detector_cnt_th0_th0_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[63-:8]),
++    .qs(wkup_detector_cnt_th0_th0_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th0_th1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th0_th1_we & regen_qs),
++    .wd(wkup_detector_cnt_th0_th1_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[71-:8]),
++    .qs(wkup_detector_cnt_th0_th1_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th0_th2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th0_th2_we & regen_qs),
++    .wd(wkup_detector_cnt_th0_th2_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[79-:8]),
++    .qs(wkup_detector_cnt_th0_th2_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th0_th3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th0_th3_we & regen_qs),
++    .wd(wkup_detector_cnt_th0_th3_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[87-:8]),
++    .qs(wkup_detector_cnt_th0_th3_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th1_th4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th1_th4_we & regen_qs),
++    .wd(wkup_detector_cnt_th1_th4_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[95-:8]),
++    .qs(wkup_detector_cnt_th1_th4_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th1_th5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th1_th5_we & regen_qs),
++    .wd(wkup_detector_cnt_th1_th5_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[103-:8]),
++    .qs(wkup_detector_cnt_th1_th5_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th1_th6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th1_th6_we & regen_qs),
++    .wd(wkup_detector_cnt_th1_th6_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[111-:8]),
++    .qs(wkup_detector_cnt_th1_th6_qs)
++  );
++  prim_subreg #(
++    .DW(8),
++    .SWACCESS("RW"),
++    .RESVAL(8'h00)
++  ) u_wkup_detector_cnt_th1_th7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_cnt_th1_th7_we & regen_qs),
++    .wd(wkup_detector_cnt_th1_th7_wd),
++    .de(1'b0),
++    .d({8 {1'b0}}),
++    .qe(),
++    .q(reg2hw[119-:8]),
++    .qs(wkup_detector_cnt_th1_th7_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel0_sel0(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel0_sel0_we & regen_qs),
++    .wd(wkup_detector_padsel0_sel0_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[20-:5]),
++    .qs(wkup_detector_padsel0_sel0_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel0_sel1(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel0_sel1_we & regen_qs),
++    .wd(wkup_detector_padsel0_sel1_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[25-:5]),
++    .qs(wkup_detector_padsel0_sel1_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel0_sel2(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel0_sel2_we & regen_qs),
++    .wd(wkup_detector_padsel0_sel2_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[30-:5]),
++    .qs(wkup_detector_padsel0_sel2_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel0_sel3(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel0_sel3_we & regen_qs),
++    .wd(wkup_detector_padsel0_sel3_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[35-:5]),
++    .qs(wkup_detector_padsel0_sel3_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel0_sel4(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel0_sel4_we & regen_qs),
++    .wd(wkup_detector_padsel0_sel4_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[40-:5]),
++    .qs(wkup_detector_padsel0_sel4_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel0_sel5(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel0_sel5_we & regen_qs),
++    .wd(wkup_detector_padsel0_sel5_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[45-:5]),
++    .qs(wkup_detector_padsel0_sel5_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel1_sel6(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel1_sel6_we & regen_qs),
++    .wd(wkup_detector_padsel1_sel6_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[50-:5]),
++    .qs(wkup_detector_padsel1_sel6_qs)
++  );
++  prim_subreg #(
++    .DW(5),
++    .SWACCESS("RW"),
++    .RESVAL(5'h00)
++  ) u_wkup_detector_padsel1_sel7(
++    .clk_i(clk_i),
++    .rst_ni(rst_ni),
++    .we(wkup_detector_padsel1_sel7_we & regen_qs),
++    .wd(wkup_detector_padsel1_sel7_wd),
++    .de(1'b0),
++    .d({5 {1'b0}}),
++    .qe(),
++    .q(reg2hw[55-:5]),
++    .qs(wkup_detector_padsel1_sel7_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause0(
++    .re(wkup_cause_cause0_re),
++    .we(wkup_cause_cause0_we & regen_qs),
++    .wd(wkup_cause_cause0_wd),
++    .d(hw2reg[0]),
++    .qre(),
++    .qe(reg2hw[0]),
++    .q(reg2hw[1]),
++    .qs(wkup_cause_cause0_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause1(
++    .re(wkup_cause_cause1_re),
++    .we(wkup_cause_cause1_we & regen_qs),
++    .wd(wkup_cause_cause1_wd),
++    .d(hw2reg[1]),
++    .qre(),
++    .qe(reg2hw[2]),
++    .q(reg2hw[3]),
++    .qs(wkup_cause_cause1_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause2(
++    .re(wkup_cause_cause2_re),
++    .we(wkup_cause_cause2_we & regen_qs),
++    .wd(wkup_cause_cause2_wd),
++    .d(hw2reg[2]),
++    .qre(),
++    .qe(reg2hw[4]),
++    .q(reg2hw[5]),
++    .qs(wkup_cause_cause2_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause3(
++    .re(wkup_cause_cause3_re),
++    .we(wkup_cause_cause3_we & regen_qs),
++    .wd(wkup_cause_cause3_wd),
++    .d(hw2reg[3]),
++    .qre(),
++    .qe(reg2hw[6]),
++    .q(reg2hw[7]),
++    .qs(wkup_cause_cause3_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause4(
++    .re(wkup_cause_cause4_re),
++    .we(wkup_cause_cause4_we & regen_qs),
++    .wd(wkup_cause_cause4_wd),
++    .d(hw2reg[4]),
++    .qre(),
++    .qe(reg2hw[8]),
++    .q(reg2hw[9]),
++    .qs(wkup_cause_cause4_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause5(
++    .re(wkup_cause_cause5_re),
++    .we(wkup_cause_cause5_we & regen_qs),
++    .wd(wkup_cause_cause5_wd),
++    .d(hw2reg[5]),
++    .qre(),
++    .qe(reg2hw[10]),
++    .q(reg2hw[11]),
++    .qs(wkup_cause_cause5_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause6(
++    .re(wkup_cause_cause6_re),
++    .we(wkup_cause_cause6_we & regen_qs),
++    .wd(wkup_cause_cause6_wd),
++    .d(hw2reg[6]),
++    .qre(),
++    .qe(reg2hw[12]),
++    .q(reg2hw[13]),
++    .qs(wkup_cause_cause6_qs)
++  );
++  prim_subreg_ext #(.DW(1)) u_wkup_cause_cause7(
++    .re(wkup_cause_cause7_re),
++    .we(wkup_cause_cause7_we & regen_qs),
++    .wd(wkup_cause_cause7_wd),
++    .d(hw2reg[7]),
++    .qre(),
++    .qe(reg2hw[14]),
++    .q(reg2hw[15]),
++    .qs(wkup_cause_cause7_qs)
+   );
+ 
+-
+-  // F[in26]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel5_in26 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel5_in26_we & regen_qs),
+-    .wd     (periph_insel5_in26_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[26].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel5_in26_qs)
+-  );
+-
+-
+-  // F[in27]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel5_in27 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel5_in27_we & regen_qs),
+-    .wd     (periph_insel5_in27_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[27].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel5_in27_qs)
+-  );
+-
+-
+-  // F[in28]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel5_in28 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel5_in28_we & regen_qs),
+-    .wd     (periph_insel5_in28_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[28].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel5_in28_qs)
+-  );
+-
+-
+-  // F[in29]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel5_in29 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel5_in29_we & regen_qs),
+-    .wd     (periph_insel5_in29_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[29].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel5_in29_qs)
+-  );
+-
+-
+-  // Subregister 30 of Multireg periph_insel
+-  // R[periph_insel6]: V(False)
+-
+-  // F[in30]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel6_in30 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel6_in30_we & regen_qs),
+-    .wd     (periph_insel6_in30_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[30].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel6_in30_qs)
+-  );
+-
+-
+-  // F[in31]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h0)
+-  ) u_periph_insel6_in31 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (periph_insel6_in31_we & regen_qs),
+-    .wd     (periph_insel6_in31_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.periph_insel[31].q ),
+-
+-    // to register interface (read)
+-    .qs     (periph_insel6_in31_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg mio_outsel
+-  // R[mio_outsel0]: V(False)
+-
+-  // F[out0]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel0_out0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel0_out0_we & regen_qs),
+-    .wd     (mio_outsel0_out0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel0_out0_qs)
+-  );
+-
+-
+-  // F[out1]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel0_out1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel0_out1_we & regen_qs),
+-    .wd     (mio_outsel0_out1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel0_out1_qs)
+-  );
+-
+-
+-  // F[out2]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel0_out2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel0_out2_we & regen_qs),
+-    .wd     (mio_outsel0_out2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel0_out2_qs)
+-  );
+-
+-
+-  // F[out3]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel0_out3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel0_out3_we & regen_qs),
+-    .wd     (mio_outsel0_out3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel0_out3_qs)
+-  );
+-
+-
+-  // F[out4]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel0_out4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel0_out4_we & regen_qs),
+-    .wd     (mio_outsel0_out4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel0_out4_qs)
+-  );
+-
+-
+-  // Subregister 5 of Multireg mio_outsel
+-  // R[mio_outsel1]: V(False)
+-
+-  // F[out5]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel1_out5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel1_out5_we & regen_qs),
+-    .wd     (mio_outsel1_out5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel1_out5_qs)
+-  );
+-
+-
+-  // F[out6]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel1_out6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel1_out6_we & regen_qs),
+-    .wd     (mio_outsel1_out6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel1_out6_qs)
+-  );
+-
+-
+-  // F[out7]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel1_out7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel1_out7_we & regen_qs),
+-    .wd     (mio_outsel1_out7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel1_out7_qs)
+-  );
+-
+-
+-  // F[out8]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel1_out8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel1_out8_we & regen_qs),
+-    .wd     (mio_outsel1_out8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel1_out8_qs)
+-  );
+-
+-
+-  // F[out9]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel1_out9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel1_out9_we & regen_qs),
+-    .wd     (mio_outsel1_out9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel1_out9_qs)
+-  );
+-
+-
+-  // Subregister 10 of Multireg mio_outsel
+-  // R[mio_outsel2]: V(False)
+-
+-  // F[out10]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel2_out10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel2_out10_we & regen_qs),
+-    .wd     (mio_outsel2_out10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel2_out10_qs)
+-  );
+-
+-
+-  // F[out11]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel2_out11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel2_out11_we & regen_qs),
+-    .wd     (mio_outsel2_out11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel2_out11_qs)
+-  );
+-
+-
+-  // F[out12]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel2_out12 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel2_out12_we & regen_qs),
+-    .wd     (mio_outsel2_out12_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[12].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel2_out12_qs)
+-  );
+-
+-
+-  // F[out13]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel2_out13 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel2_out13_we & regen_qs),
+-    .wd     (mio_outsel2_out13_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[13].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel2_out13_qs)
+-  );
+-
+-
+-  // F[out14]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel2_out14 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel2_out14_we & regen_qs),
+-    .wd     (mio_outsel2_out14_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[14].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel2_out14_qs)
+-  );
+-
+-
+-  // Subregister 15 of Multireg mio_outsel
+-  // R[mio_outsel3]: V(False)
+-
+-  // F[out15]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel3_out15 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel3_out15_we & regen_qs),
+-    .wd     (mio_outsel3_out15_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[15].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel3_out15_qs)
+-  );
+-
+-
+-  // F[out16]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel3_out16 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel3_out16_we & regen_qs),
+-    .wd     (mio_outsel3_out16_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[16].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel3_out16_qs)
+-  );
+-
+-
+-  // F[out17]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel3_out17 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel3_out17_we & regen_qs),
+-    .wd     (mio_outsel3_out17_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[17].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel3_out17_qs)
+-  );
+-
+-
+-  // F[out18]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel3_out18 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel3_out18_we & regen_qs),
+-    .wd     (mio_outsel3_out18_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[18].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel3_out18_qs)
+-  );
+-
+-
+-  // F[out19]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel3_out19 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel3_out19_we & regen_qs),
+-    .wd     (mio_outsel3_out19_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[19].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel3_out19_qs)
+-  );
+-
+-
+-  // Subregister 20 of Multireg mio_outsel
+-  // R[mio_outsel4]: V(False)
+-
+-  // F[out20]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel4_out20 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel4_out20_we & regen_qs),
+-    .wd     (mio_outsel4_out20_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[20].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel4_out20_qs)
+-  );
+-
+-
+-  // F[out21]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel4_out21 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel4_out21_we & regen_qs),
+-    .wd     (mio_outsel4_out21_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[21].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel4_out21_qs)
+-  );
+-
+-
+-  // F[out22]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel4_out22 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel4_out22_we & regen_qs),
+-    .wd     (mio_outsel4_out22_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[22].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel4_out22_qs)
+-  );
+-
+-
+-  // F[out23]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel4_out23 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel4_out23_we & regen_qs),
+-    .wd     (mio_outsel4_out23_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[23].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel4_out23_qs)
+-  );
+-
+-
+-  // F[out24]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel4_out24 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel4_out24_we & regen_qs),
+-    .wd     (mio_outsel4_out24_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[24].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel4_out24_qs)
+-  );
+-
+-
+-  // Subregister 25 of Multireg mio_outsel
+-  // R[mio_outsel5]: V(False)
+-
+-  // F[out25]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel5_out25 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel5_out25_we & regen_qs),
+-    .wd     (mio_outsel5_out25_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[25].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel5_out25_qs)
+-  );
+-
+-
+-  // F[out26]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel5_out26 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel5_out26_we & regen_qs),
+-    .wd     (mio_outsel5_out26_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[26].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel5_out26_qs)
+-  );
+-
+-
+-  // F[out27]: 17:12
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel5_out27 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel5_out27_we & regen_qs),
+-    .wd     (mio_outsel5_out27_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[27].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel5_out27_qs)
+-  );
+-
+-
+-  // F[out28]: 23:18
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel5_out28 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel5_out28_we & regen_qs),
+-    .wd     (mio_outsel5_out28_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[28].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel5_out28_qs)
+-  );
+-
+-
+-  // F[out29]: 29:24
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel5_out29 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel5_out29_we & regen_qs),
+-    .wd     (mio_outsel5_out29_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[29].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel5_out29_qs)
+-  );
+-
+-
+-  // Subregister 30 of Multireg mio_outsel
+-  // R[mio_outsel6]: V(False)
+-
+-  // F[out30]: 5:0
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel6_out30 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel6_out30_we & regen_qs),
+-    .wd     (mio_outsel6_out30_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[30].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel6_out30_qs)
+-  );
+-
+-
+-  // F[out31]: 11:6
+-  prim_subreg #(
+-    .DW      (6),
+-    .SWACCESS("RW"),
+-    .RESVAL  (6'h2)
+-  ) u_mio_outsel6_out31 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_outsel6_out31_we & regen_qs),
+-    .wd     (mio_outsel6_out31_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_outsel[31].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_outsel6_out31_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg mio_out_sleep_val
+-  // R[mio_out_sleep_val0]: V(False)
+-
+-  // F[out0]: 1:0
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out0_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out0_qs)
+-  );
+-
+-
+-  // F[out1]: 3:2
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out1_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out1_qs)
+-  );
+-
+-
+-  // F[out2]: 5:4
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out2_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out2_qs)
+-  );
+-
+-
+-  // F[out3]: 7:6
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out3_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out3_qs)
+-  );
+-
+-
+-  // F[out4]: 9:8
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out4_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out4_qs)
+-  );
+-
+-
+-  // F[out5]: 11:10
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out5_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out5_qs)
+-  );
+-
+-
+-  // F[out6]: 13:12
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out6_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out6_qs)
+-  );
+-
+-
+-  // F[out7]: 15:14
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out7_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out7_qs)
+-  );
+-
+-
+-  // F[out8]: 17:16
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out8_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out8_qs)
+-  );
+-
+-
+-  // F[out9]: 19:18
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out9_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out9_qs)
+-  );
+-
+-
+-  // F[out10]: 21:20
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out10_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out10_qs)
+-  );
+-
+-
+-  // F[out11]: 23:22
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out11_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out11_qs)
+-  );
+-
+-
+-  // F[out12]: 25:24
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out12 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out12_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out12_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[12].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out12_qs)
+-  );
+-
+-
+-  // F[out13]: 27:26
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out13 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out13_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out13_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[13].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out13_qs)
+-  );
+-
+-
+-  // F[out14]: 29:28
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out14 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out14_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out14_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[14].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out14_qs)
+-  );
+-
+-
+-  // F[out15]: 31:30
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val0_out15 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val0_out15_we & regen_qs),
+-    .wd     (mio_out_sleep_val0_out15_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[15].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val0_out15_qs)
+-  );
+-
+-
+-  // Subregister 16 of Multireg mio_out_sleep_val
+-  // R[mio_out_sleep_val1]: V(False)
+-
+-  // F[out16]: 1:0
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out16 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out16_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out16_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[16].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out16_qs)
+-  );
+-
+-
+-  // F[out17]: 3:2
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out17 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out17_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out17_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[17].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out17_qs)
+-  );
+-
+-
+-  // F[out18]: 5:4
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out18 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out18_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out18_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[18].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out18_qs)
+-  );
+-
+-
+-  // F[out19]: 7:6
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out19 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out19_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out19_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[19].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out19_qs)
+-  );
+-
+-
+-  // F[out20]: 9:8
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out20 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out20_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out20_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[20].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out20_qs)
+-  );
+-
+-
+-  // F[out21]: 11:10
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out21 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out21_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out21_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[21].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out21_qs)
+-  );
+-
+-
+-  // F[out22]: 13:12
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out22 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out22_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out22_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[22].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out22_qs)
+-  );
+-
+-
+-  // F[out23]: 15:14
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out23 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out23_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out23_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[23].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out23_qs)
+-  );
+-
+-
+-  // F[out24]: 17:16
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out24 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out24_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out24_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[24].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out24_qs)
+-  );
+-
+-
+-  // F[out25]: 19:18
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out25 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out25_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out25_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[25].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out25_qs)
+-  );
+-
+-
+-  // F[out26]: 21:20
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out26 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out26_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out26_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[26].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out26_qs)
+-  );
+-
+-
+-  // F[out27]: 23:22
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out27 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out27_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out27_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[27].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out27_qs)
+-  );
+-
+-
+-  // F[out28]: 25:24
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out28 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out28_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out28_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[28].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out28_qs)
+-  );
+-
+-
+-  // F[out29]: 27:26
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out29 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out29_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out29_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[29].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out29_qs)
+-  );
+-
+-
+-  // F[out30]: 29:28
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out30 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out30_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out30_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[30].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out30_qs)
+-  );
+-
+-
+-  // F[out31]: 31:30
+-  prim_subreg #(
+-    .DW      (2),
+-    .SWACCESS("RW"),
+-    .RESVAL  (2'h2)
+-  ) u_mio_out_sleep_val1_out31 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (mio_out_sleep_val1_out31_we & regen_qs),
+-    .wd     (mio_out_sleep_val1_out31_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.mio_out_sleep_val[31].q ),
+-
+-    // to register interface (read)
+-    .qs     (mio_out_sleep_val1_out31_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg dio_out_sleep_val
+-  // R[dio_out_sleep_val]: V(True)
+-
+-  // F[out0]: 1:0
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out0 (
+-    .re     (dio_out_sleep_val_out0_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out0_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out0_wd),
+-    .d      (hw2reg.dio_out_sleep_val[0].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[0].qe),
+-    .q      (reg2hw.dio_out_sleep_val[0].q ),
+-    .qs     (dio_out_sleep_val_out0_qs)
+-  );
+-
+-
+-  // F[out1]: 3:2
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out1 (
+-    .re     (dio_out_sleep_val_out1_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out1_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out1_wd),
+-    .d      (hw2reg.dio_out_sleep_val[1].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[1].qe),
+-    .q      (reg2hw.dio_out_sleep_val[1].q ),
+-    .qs     (dio_out_sleep_val_out1_qs)
+-  );
+-
+-
+-  // F[out2]: 5:4
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out2 (
+-    .re     (dio_out_sleep_val_out2_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out2_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out2_wd),
+-    .d      (hw2reg.dio_out_sleep_val[2].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[2].qe),
+-    .q      (reg2hw.dio_out_sleep_val[2].q ),
+-    .qs     (dio_out_sleep_val_out2_qs)
+-  );
+-
+-
+-  // F[out3]: 7:6
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out3 (
+-    .re     (dio_out_sleep_val_out3_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out3_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out3_wd),
+-    .d      (hw2reg.dio_out_sleep_val[3].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[3].qe),
+-    .q      (reg2hw.dio_out_sleep_val[3].q ),
+-    .qs     (dio_out_sleep_val_out3_qs)
+-  );
+-
+-
+-  // F[out4]: 9:8
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out4 (
+-    .re     (dio_out_sleep_val_out4_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out4_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out4_wd),
+-    .d      (hw2reg.dio_out_sleep_val[4].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[4].qe),
+-    .q      (reg2hw.dio_out_sleep_val[4].q ),
+-    .qs     (dio_out_sleep_val_out4_qs)
+-  );
+-
+-
+-  // F[out5]: 11:10
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out5 (
+-    .re     (dio_out_sleep_val_out5_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out5_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out5_wd),
+-    .d      (hw2reg.dio_out_sleep_val[5].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[5].qe),
+-    .q      (reg2hw.dio_out_sleep_val[5].q ),
+-    .qs     (dio_out_sleep_val_out5_qs)
+-  );
+-
+-
+-  // F[out6]: 13:12
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out6 (
+-    .re     (dio_out_sleep_val_out6_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out6_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out6_wd),
+-    .d      (hw2reg.dio_out_sleep_val[6].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[6].qe),
+-    .q      (reg2hw.dio_out_sleep_val[6].q ),
+-    .qs     (dio_out_sleep_val_out6_qs)
+-  );
+-
+-
+-  // F[out7]: 15:14
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out7 (
+-    .re     (dio_out_sleep_val_out7_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out7_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out7_wd),
+-    .d      (hw2reg.dio_out_sleep_val[7].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[7].qe),
+-    .q      (reg2hw.dio_out_sleep_val[7].q ),
+-    .qs     (dio_out_sleep_val_out7_qs)
+-  );
+-
+-
+-  // F[out8]: 17:16
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out8 (
+-    .re     (dio_out_sleep_val_out8_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out8_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out8_wd),
+-    .d      (hw2reg.dio_out_sleep_val[8].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[8].qe),
+-    .q      (reg2hw.dio_out_sleep_val[8].q ),
+-    .qs     (dio_out_sleep_val_out8_qs)
+-  );
+-
+-
+-  // F[out9]: 19:18
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out9 (
+-    .re     (dio_out_sleep_val_out9_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out9_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out9_wd),
+-    .d      (hw2reg.dio_out_sleep_val[9].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[9].qe),
+-    .q      (reg2hw.dio_out_sleep_val[9].q ),
+-    .qs     (dio_out_sleep_val_out9_qs)
+-  );
+-
+-
+-  // F[out10]: 21:20
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out10 (
+-    .re     (dio_out_sleep_val_out10_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out10_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out10_wd),
+-    .d      (hw2reg.dio_out_sleep_val[10].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[10].qe),
+-    .q      (reg2hw.dio_out_sleep_val[10].q ),
+-    .qs     (dio_out_sleep_val_out10_qs)
+-  );
+-
+-
+-  // F[out11]: 23:22
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out11 (
+-    .re     (dio_out_sleep_val_out11_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out11_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out11_wd),
+-    .d      (hw2reg.dio_out_sleep_val[11].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[11].qe),
+-    .q      (reg2hw.dio_out_sleep_val[11].q ),
+-    .qs     (dio_out_sleep_val_out11_qs)
+-  );
+-
+-
+-  // F[out12]: 25:24
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out12 (
+-    .re     (dio_out_sleep_val_out12_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out12_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out12_wd),
+-    .d      (hw2reg.dio_out_sleep_val[12].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[12].qe),
+-    .q      (reg2hw.dio_out_sleep_val[12].q ),
+-    .qs     (dio_out_sleep_val_out12_qs)
+-  );
+-
+-
+-  // F[out13]: 27:26
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out13 (
+-    .re     (dio_out_sleep_val_out13_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out13_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out13_wd),
+-    .d      (hw2reg.dio_out_sleep_val[13].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[13].qe),
+-    .q      (reg2hw.dio_out_sleep_val[13].q ),
+-    .qs     (dio_out_sleep_val_out13_qs)
+-  );
+-
+-
+-  // F[out14]: 29:28
+-  prim_subreg_ext #(
+-    .DW    (2)
+-  ) u_dio_out_sleep_val_out14 (
+-    .re     (dio_out_sleep_val_out14_re),
+-    // qualified with register enable
+-    .we     (dio_out_sleep_val_out14_we & regen_qs),
+-    .wd     (dio_out_sleep_val_out14_wd),
+-    .d      (hw2reg.dio_out_sleep_val[14].d),
+-    .qre    (),
+-    .qe     (reg2hw.dio_out_sleep_val[14].qe),
+-    .q      (reg2hw.dio_out_sleep_val[14].q ),
+-    .qs     (dio_out_sleep_val_out14_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg wkup_detector_en
+-  // R[wkup_detector_en]: V(False)
+-
+-  // F[en0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en0_we & regen_qs),
+-    .wd     (wkup_detector_en_en0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en0_qs)
+-  );
+-
+-
+-  // F[en1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en1_we & regen_qs),
+-    .wd     (wkup_detector_en_en1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en1_qs)
+-  );
+-
+-
+-  // F[en2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en2_we & regen_qs),
+-    .wd     (wkup_detector_en_en2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en2_qs)
+-  );
+-
+-
+-  // F[en3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en3_we & regen_qs),
+-    .wd     (wkup_detector_en_en3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en3_qs)
+-  );
+-
+-
+-  // F[en4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en4_we & regen_qs),
+-    .wd     (wkup_detector_en_en4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en4_qs)
+-  );
+-
+-
+-  // F[en5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en5_we & regen_qs),
+-    .wd     (wkup_detector_en_en5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en5_qs)
+-  );
+-
+-
+-  // F[en6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en6_we & regen_qs),
+-    .wd     (wkup_detector_en_en6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en6_qs)
+-  );
+-
+-
+-  // F[en7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector_en_en7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_en_en7_we & regen_qs),
+-    .wd     (wkup_detector_en_en7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_en[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_en_en7_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg wkup_detector
+-  // R[wkup_detector0]: V(False)
+-
+-  // F[mode0]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector0_mode0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector0_mode0_we & regen_qs),
+-    .wd     (wkup_detector0_mode0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[0].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector0_mode0_qs)
+-  );
+-
+-
+-  // F[filter0]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector0_filter0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector0_filter0_we & regen_qs),
+-    .wd     (wkup_detector0_filter0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[0].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector0_filter0_qs)
+-  );
+-
+-
+-  // F[miodio0]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector0_miodio0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector0_miodio0_we & regen_qs),
+-    .wd     (wkup_detector0_miodio0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[0].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector0_miodio0_qs)
+-  );
+-
+-
+-  // Subregister 1 of Multireg wkup_detector
+-  // R[wkup_detector1]: V(False)
+-
+-  // F[mode1]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector1_mode1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector1_mode1_we & regen_qs),
+-    .wd     (wkup_detector1_mode1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[1].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector1_mode1_qs)
+-  );
+-
+-
+-  // F[filter1]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector1_filter1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector1_filter1_we & regen_qs),
+-    .wd     (wkup_detector1_filter1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[1].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector1_filter1_qs)
+-  );
+-
+-
+-  // F[miodio1]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector1_miodio1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector1_miodio1_we & regen_qs),
+-    .wd     (wkup_detector1_miodio1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[1].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector1_miodio1_qs)
+-  );
+-
+-
+-  // Subregister 2 of Multireg wkup_detector
+-  // R[wkup_detector2]: V(False)
+-
+-  // F[mode2]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector2_mode2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector2_mode2_we & regen_qs),
+-    .wd     (wkup_detector2_mode2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[2].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector2_mode2_qs)
+-  );
+-
+-
+-  // F[filter2]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector2_filter2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector2_filter2_we & regen_qs),
+-    .wd     (wkup_detector2_filter2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[2].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector2_filter2_qs)
+-  );
+-
+-
+-  // F[miodio2]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector2_miodio2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector2_miodio2_we & regen_qs),
+-    .wd     (wkup_detector2_miodio2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[2].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector2_miodio2_qs)
+-  );
+-
+-
+-  // Subregister 3 of Multireg wkup_detector
+-  // R[wkup_detector3]: V(False)
+-
+-  // F[mode3]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector3_mode3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector3_mode3_we & regen_qs),
+-    .wd     (wkup_detector3_mode3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[3].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector3_mode3_qs)
+-  );
+-
+-
+-  // F[filter3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector3_filter3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector3_filter3_we & regen_qs),
+-    .wd     (wkup_detector3_filter3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[3].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector3_filter3_qs)
+-  );
+-
+-
+-  // F[miodio3]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector3_miodio3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector3_miodio3_we & regen_qs),
+-    .wd     (wkup_detector3_miodio3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[3].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector3_miodio3_qs)
+-  );
+-
+-
+-  // Subregister 4 of Multireg wkup_detector
+-  // R[wkup_detector4]: V(False)
+-
+-  // F[mode4]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector4_mode4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector4_mode4_we & regen_qs),
+-    .wd     (wkup_detector4_mode4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[4].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector4_mode4_qs)
+-  );
+-
+-
+-  // F[filter4]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector4_filter4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector4_filter4_we & regen_qs),
+-    .wd     (wkup_detector4_filter4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[4].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector4_filter4_qs)
+-  );
+-
+-
+-  // F[miodio4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector4_miodio4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector4_miodio4_we & regen_qs),
+-    .wd     (wkup_detector4_miodio4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[4].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector4_miodio4_qs)
+-  );
+-
+-
+-  // Subregister 5 of Multireg wkup_detector
+-  // R[wkup_detector5]: V(False)
+-
+-  // F[mode5]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector5_mode5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector5_mode5_we & regen_qs),
+-    .wd     (wkup_detector5_mode5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[5].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector5_mode5_qs)
+-  );
+-
+-
+-  // F[filter5]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector5_filter5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector5_filter5_we & regen_qs),
+-    .wd     (wkup_detector5_filter5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[5].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector5_filter5_qs)
+-  );
+-
+-
+-  // F[miodio5]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector5_miodio5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector5_miodio5_we & regen_qs),
+-    .wd     (wkup_detector5_miodio5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[5].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector5_miodio5_qs)
+-  );
+-
+-
+-  // Subregister 6 of Multireg wkup_detector
+-  // R[wkup_detector6]: V(False)
+-
+-  // F[mode6]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector6_mode6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector6_mode6_we & regen_qs),
+-    .wd     (wkup_detector6_mode6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[6].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector6_mode6_qs)
+-  );
+-
+-
+-  // F[filter6]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector6_filter6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector6_filter6_we & regen_qs),
+-    .wd     (wkup_detector6_filter6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[6].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector6_filter6_qs)
+-  );
+-
+-
+-  // F[miodio6]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector6_miodio6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector6_miodio6_we & regen_qs),
+-    .wd     (wkup_detector6_miodio6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[6].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector6_miodio6_qs)
+-  );
+-
+-
+-  // Subregister 7 of Multireg wkup_detector
+-  // R[wkup_detector7]: V(False)
+-
+-  // F[mode7]: 2:0
+-  prim_subreg #(
+-    .DW      (3),
+-    .SWACCESS("RW"),
+-    .RESVAL  (3'h0)
+-  ) u_wkup_detector7_mode7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector7_mode7_we & regen_qs),
+-    .wd     (wkup_detector7_mode7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[7].mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector7_mode7_qs)
+-  );
+-
+-
+-  // F[filter7]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector7_filter7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector7_filter7_we & regen_qs),
+-    .wd     (wkup_detector7_filter7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[7].filter.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector7_filter7_qs)
+-  );
+-
+-
+-  // F[miodio7]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_wkup_detector7_miodio7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector7_miodio7_we & regen_qs),
+-    .wd     (wkup_detector7_miodio7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector[7].miodio.q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector7_miodio7_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg wkup_detector_cnt_th
+-  // R[wkup_detector_cnt_th0]: V(False)
+-
+-  // F[th0]: 7:0
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th0_th0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th0_th0_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th0_th0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th0_th0_qs)
+-  );
+-
+-
+-  // F[th1]: 15:8
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th0_th1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th0_th1_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th0_th1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th0_th1_qs)
+-  );
+-
+-
+-  // F[th2]: 23:16
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th0_th2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th0_th2_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th0_th2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th0_th2_qs)
+-  );
+-
+-
+-  // F[th3]: 31:24
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th0_th3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th0_th3_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th0_th3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th0_th3_qs)
+-  );
+-
+-
+-  // Subregister 4 of Multireg wkup_detector_cnt_th
+-  // R[wkup_detector_cnt_th1]: V(False)
+-
+-  // F[th4]: 7:0
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th1_th4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th1_th4_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th1_th4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th1_th4_qs)
+-  );
+-
+-
+-  // F[th5]: 15:8
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th1_th5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th1_th5_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th1_th5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th1_th5_qs)
+-  );
+-
+-
+-  // F[th6]: 23:16
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th1_th6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th1_th6_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th1_th6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th1_th6_qs)
+-  );
+-
+-
+-  // F[th7]: 31:24
+-  prim_subreg #(
+-    .DW      (8),
+-    .SWACCESS("RW"),
+-    .RESVAL  (8'h0)
+-  ) u_wkup_detector_cnt_th1_th7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_cnt_th1_th7_we & regen_qs),
+-    .wd     (wkup_detector_cnt_th1_th7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_cnt_th[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_cnt_th1_th7_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg wkup_detector_padsel
+-  // R[wkup_detector_padsel0]: V(False)
+-
+-  // F[sel0]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel0_sel0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel0_sel0_we & regen_qs),
+-    .wd     (wkup_detector_padsel0_sel0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel0_sel0_qs)
+-  );
+-
+-
+-  // F[sel1]: 9:5
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel0_sel1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel0_sel1_we & regen_qs),
+-    .wd     (wkup_detector_padsel0_sel1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel0_sel1_qs)
+-  );
+-
+-
+-  // F[sel2]: 14:10
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel0_sel2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel0_sel2_we & regen_qs),
+-    .wd     (wkup_detector_padsel0_sel2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel0_sel2_qs)
+-  );
+-
+-
+-  // F[sel3]: 19:15
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel0_sel3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel0_sel3_we & regen_qs),
+-    .wd     (wkup_detector_padsel0_sel3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel0_sel3_qs)
+-  );
+-
+-
+-  // F[sel4]: 24:20
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel0_sel4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel0_sel4_we & regen_qs),
+-    .wd     (wkup_detector_padsel0_sel4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel0_sel4_qs)
+-  );
+-
+-
+-  // F[sel5]: 29:25
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel0_sel5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel0_sel5_we & regen_qs),
+-    .wd     (wkup_detector_padsel0_sel5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel0_sel5_qs)
+-  );
+-
+-
+-  // Subregister 6 of Multireg wkup_detector_padsel
+-  // R[wkup_detector_padsel1]: V(False)
+-
+-  // F[sel6]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel1_sel6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel1_sel6_we & regen_qs),
+-    .wd     (wkup_detector_padsel1_sel6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel1_sel6_qs)
+-  );
+-
+-
+-  // F[sel7]: 9:5
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_wkup_detector_padsel1_sel7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface (qualified with register enable)
+-    .we     (wkup_detector_padsel1_sel7_we & regen_qs),
+-    .wd     (wkup_detector_padsel1_sel7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.wkup_detector_padsel[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (wkup_detector_padsel1_sel7_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg wkup_cause
+-  // R[wkup_cause]: V(True)
+-
+-  // F[cause0]: 0:0
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause0 (
+-    .re     (wkup_cause_cause0_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause0_we & regen_qs),
+-    .wd     (wkup_cause_cause0_wd),
+-    .d      (hw2reg.wkup_cause[0].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[0].qe),
+-    .q      (reg2hw.wkup_cause[0].q ),
+-    .qs     (wkup_cause_cause0_qs)
+-  );
+-
+-
+-  // F[cause1]: 1:1
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause1 (
+-    .re     (wkup_cause_cause1_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause1_we & regen_qs),
+-    .wd     (wkup_cause_cause1_wd),
+-    .d      (hw2reg.wkup_cause[1].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[1].qe),
+-    .q      (reg2hw.wkup_cause[1].q ),
+-    .qs     (wkup_cause_cause1_qs)
+-  );
+-
+-
+-  // F[cause2]: 2:2
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause2 (
+-    .re     (wkup_cause_cause2_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause2_we & regen_qs),
+-    .wd     (wkup_cause_cause2_wd),
+-    .d      (hw2reg.wkup_cause[2].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[2].qe),
+-    .q      (reg2hw.wkup_cause[2].q ),
+-    .qs     (wkup_cause_cause2_qs)
+-  );
+-
+-
+-  // F[cause3]: 3:3
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause3 (
+-    .re     (wkup_cause_cause3_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause3_we & regen_qs),
+-    .wd     (wkup_cause_cause3_wd),
+-    .d      (hw2reg.wkup_cause[3].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[3].qe),
+-    .q      (reg2hw.wkup_cause[3].q ),
+-    .qs     (wkup_cause_cause3_qs)
+-  );
+-
+-
+-  // F[cause4]: 4:4
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause4 (
+-    .re     (wkup_cause_cause4_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause4_we & regen_qs),
+-    .wd     (wkup_cause_cause4_wd),
+-    .d      (hw2reg.wkup_cause[4].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[4].qe),
+-    .q      (reg2hw.wkup_cause[4].q ),
+-    .qs     (wkup_cause_cause4_qs)
+-  );
+-
+-
+-  // F[cause5]: 5:5
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause5 (
+-    .re     (wkup_cause_cause5_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause5_we & regen_qs),
+-    .wd     (wkup_cause_cause5_wd),
+-    .d      (hw2reg.wkup_cause[5].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[5].qe),
+-    .q      (reg2hw.wkup_cause[5].q ),
+-    .qs     (wkup_cause_cause5_qs)
+-  );
+-
+-
+-  // F[cause6]: 6:6
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause6 (
+-    .re     (wkup_cause_cause6_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause6_we & regen_qs),
+-    .wd     (wkup_cause_cause6_wd),
+-    .d      (hw2reg.wkup_cause[6].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[6].qe),
+-    .q      (reg2hw.wkup_cause[6].q ),
+-    .qs     (wkup_cause_cause6_qs)
+-  );
+-
+-
+-  // F[cause7]: 7:7
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_wkup_cause_cause7 (
+-    .re     (wkup_cause_cause7_re),
+-    // qualified with register enable
+-    .we     (wkup_cause_cause7_we & regen_qs),
+-    .wd     (wkup_cause_cause7_wd),
+-    .d      (hw2reg.wkup_cause[7].d),
+-    .qre    (),
+-    .qe     (reg2hw.wkup_cause[7].qe),
+-    .q      (reg2hw.wkup_cause[7].q ),
+-    .qs     (wkup_cause_cause7_qs)
+-  );
+-
+-
+-
+-
+-
++  // Register instances
++  // R[regen]: V(False)
+   logic [31:0] addr_hit;
+   always_comb begin
+-    addr_hit = '0;
++    addr_hit = {32 {1'b0}};
+     addr_hit[ 0] = (reg_addr == PINMUX_REGEN_OFFSET);
+     addr_hit[ 1] = (reg_addr == PINMUX_PERIPH_INSEL0_OFFSET);
+     addr_hit[ 2] = (reg_addr == PINMUX_PERIPH_INSEL1_OFFSET);
+@@ -5457,7 +3613,7 @@ module pinmux_reg_top (
+ 
+   // Read data return
+   always_comb begin
+-    reg_rdata_next = '0;
++    reg_rdata_next = {32 {1'b0}};
+     unique case (1'b1)
+       addr_hit[0]: begin
+         reg_rdata_next[0] = regen_qs;
+@@ -5724,7 +3880,7 @@ module pinmux_reg_top (
+       end
+ 
+       default: begin
+-        reg_rdata_next = '1;
++        reg_rdata_next = {32 {1'b1}};
+       end
+     endcase
+   end
 diff --git a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
 index 61469937f..12f0a2bcd 100644
 --- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -411,6 +411,46 @@ index 052cb2f5a..b62227975 100644
  
    // Create Socket_1n
    tlul_socket_1n #(
+diff --git a/hw/ip/pinmux/rtl/pinmux_wkup.sv b/hw/ip/pinmux/rtl/pinmux_wkup.sv
+index 101062346..2eb8496b3 100644
+--- a/hw/ip/pinmux/rtl/pinmux_wkup.sv
++++ b/hw/ip/pinmux/rtl/pinmux_wkup.sv
+@@ -2,7 +2,7 @@
+ // Licensed under the Apache License, Version 2.0, see LICENSE for details.
+ // SPDX-License-Identifier: Apache-2.0
+ //
+-module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
++module pinmux_wkup import pinmux_pkg::*; #(
+   parameter int Cycles = 4
+ ) (
+   input                    clk_i,
+@@ -16,7 +16,7 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
+   input                    wkup_en_i,
+   input                    filter_en_i,
+   input wkup_mode_e        wkup_mode_i,
+-  input [WkupCntWidth-1:0] wkup_cnt_th_i,
++  input [7:0] wkup_cnt_th_i,
+   input                    pin_value_i,
+   // Signals to/from cause register.
+   // They are synched to/from the AON clock internally
+@@ -37,7 +37,7 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
+   wkup_mode_e aon_wkup_mode_q;
+   logic aon_filter_en_q;
+   logic aon_wkup_en_d, aon_wkup_en_q;
+-  logic [WkupCntWidth-1:0] aon_wkup_cnt_th_q;
++  logic [7:0] aon_wkup_cnt_th_q;
+ 
+   prim_flop_2sync #(
+     .Width(1)
+@@ -106,7 +106,7 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
+   assign aon_rising  =  aon_filter_out_d & ~aon_filter_out_q;
+ 
+   logic aon_cnt_en, aon_cnt_eq_th;
+-  logic [WkupCntWidth-1:0] aon_cnt_d, aon_cnt_q;
++  logic [7:0] aon_cnt_d, aon_cnt_q;
+   assign aon_cnt_d = (aon_cnt_eq_th) ? '0                :
+                      (aon_cnt_en)    ?  aon_cnt_q + 1'b1 : '0;
+ 
 diff --git a/hw/ip/prim/rtl/prim_arbiter_ppc.sv b/hw/ip/prim/rtl/prim_arbiter_ppc.sv
 index 9ec473f85..86bef1e9d 100644
 --- a/hw/ip/prim/rtl/prim_arbiter_ppc.sv

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -59,7 +59,6 @@ prim_subreg_ext.sv \
 prim_generic_clock_inv.sv \
 prim_ram_1p_adv.sv \
 prim_ram_2p_async_adv.sv \
-prim_filter.sv \
 prim_alert_sender.sv \
 tlul_adapter_host.sv \
 ibex_dummy_instr.sv \
@@ -93,7 +92,6 @@ hmac.sv \
 jtag_mux.sv \
 padring.sv \
 padctrl.sv \
-pinmux_wkup.sv \
 pinmux.sv \
 rv_timer_reg_top.sv \
 rv_timer.sv \
@@ -148,6 +146,8 @@ otbn_pkg.sv \
 tl_peri_pkg.sv \
 usbdev_reg_pkg.sv \
 gpio_reg_pkg.sv \
+pinmux_pkg.sv \
+pinmux_reg_pkg.sv \
 ibex_compressed_decoder.sv \
 ibex_alu.sv \
 ibex_controller.sv \
@@ -311,6 +311,8 @@ uart.sv \
 prim_sram_arbiter.sv \
 spi_device.sv \
 sha2.sv \
+prim_filter.sv \
+pinmux_wkup.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -419,12 +421,9 @@ ${UHDM_file}: ${SV2V_FILE}
 			-top flash_prog_ctrl \
 			-top flash_erase_ctrl \
 			-top flash_phy \
-			-top sha2_pad \
 			-top prim_packer \
 			-top hmac_core \
 			-top nmi_gen \
-			-top otbn_reg_top \
-			-top otbn_core \
 			-top prim_generic_pad_wrapper \
 			-top prim_pad_wrapper \
 			-top prim_pulse_sync \
@@ -436,12 +435,6 @@ ${UHDM_file}: ${SV2V_FILE}
 			-top rv_plic_target \
 			-top rv_plic_gateway \
 			-top timer_core \
-			-top spi_fwmode \
-			-top prim_ram_2p_adv \
-			-top spi_fwm_rxf_ctrl \
-			-top spi_fwm_txf_ctrl \
-			-top spi_device_reg_top \
-			-top usbdev_flop_2syncpulse \
 			-top usbdev_usbif \
 			-top xbar_main \
 			-top otbn \
@@ -451,6 +444,8 @@ ${UHDM_file}: ${SV2V_FILE}
 			-top uart \
 			-top spi_device \
 			-top sha2 \
+			-top pinmux_wkup \
+			-top usbdev_flop_2syncpulse \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})
@@ -490,7 +485,6 @@ ${UHDM_file}: ${SV2V_FILE}
 	# Delete -top alert_handler_esc_timer when alert_handler will be added to uhdm
 	# Delete -top alert_handler_class when alert_handler will be added to uhdm
 	# Delete -top aes_prng when aes will be added to uhdm
-	# Delete -top dm_dm when top_earlgrey will be added to uhdm
 	# Delete -top flash_rd_ctrl when flash_ctrl will be added to uhdm
 		# -PAddrW=17 \
 		# -PDataW=32 \
@@ -499,22 +493,13 @@ ${UHDM_file}: ${SV2V_FILE}
 		# -PWordsPerPage=256 \
 		# -PPagesPerBank=256 \
 		# -PEraseBitWidth=1 \
-	# Delete -top flash_phy when top_earlgrey will be added to uhdm
-	# Delete -top sha2_pad when sha2 will be added to uhdm
 	# Delete -top prim_packer when hmac will be added to uhdm
 	# Delete -top hmac_core when hmac will be added to uhdm
-	# Delete -top nmi_gen when top_earlgrey will be added to uhdm
-	# Delete -top otbn_reg_top when otbn will be added to uhdm
-	# Delete -top otbn_core when otbn will be added to uhdm
 	# Delete -top prim_generic_pad_wrapper when padctrl will be added to uhdm
 	# Delete -top prim_pad_wrapper when padring will be added to uhdm
 		# -PVariant=0 \
 		# -PAttrDw=10 \
 	# Delete -top prim_pulse_sync when pinmux_wkup will be added to uhdm
-	# Delete -top prim_rom_adv when top_earlgrey will be added to uhdm
-		# -PMemInitFile=boot_rom_fpga_nexysvideo.32.vmem \
-		# -PDepth=4096 \
-		# -PWidth=32 \
 	# Delete -top prim_filter_ctr when gpio will be added to uhdm
 	# Delete -top pwrmgr_fsm when pwrmgr will be added to uhdm
 	# Delete -top pwrmgr_slow_fsm when pwrmgr will be added to uhdm
@@ -525,13 +510,16 @@ ${UHDM_file}: ${SV2V_FILE}
 		# -PN_SOURCE=83 \
 		# -PMAX_PRIO=3 \
 	# Delete -top timer_core when rv_timer will be added to uhdm
-	# Delete -top spi_fwmode when spi_device will be added to uhdm
-	# Delete -top prim_ram_2p_adv when spi_device will be added to uhdm
-	# Delete -top spi_fwm_rxf_ctrl when spi_device will be added to uhdm
-	# Delete -top spi_fwm_txf_ctrl when spi_device will be added to uhdm
-	# Delete -top spi_device_reg_top when spi_device will be added to uhdm
-	# Delete -top usbdev_flop_2syncpulse when usbdev_usbif will be added to uhdm
+	# Delete -top dm_dm when top_earlgrey will be added to uhdm
+	# Delete -top flash_phy when top_earlgrey will be added to uhdm
+	# Delete -top nmi_gen when top_earlgrey will be added to uhdm
+	# Delete -top prim_rom_adv when top_earlgrey will be added to uhdm
+		# -PMemInitFile=boot_rom_fpga_nexysvideo.32.vmem \
+		# -PDepth=4096 \
+		# -PWidth=32 \
 	# Delete -top otbn when top_earlgrey will be added to uhdm
+	# Delete -top spi_device when top_earlgrey will be added to uhdm
+	# Delete -top usbdev_flop_2syncpulse when usbdev will be added to uhdm
 
 uhdm/yosys/synth-opentitan: ${UHDM_file} ${SV2V_FILE} | ${VENV_OT}
 	(cd ${root_dir}/build && \

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -41,7 +41,6 @@ prim_lfsr.sv \
 prim_intr_hw.sv \
 alert_handler_reg_top.sv \
 padctrl_reg_top.sv \
-pinmux_reg_top.sv \
 pwrmgr_reg_top.sv \
 ibex_icache.sv \
 prim_dom_and_2share.sv \
@@ -92,7 +91,6 @@ hmac.sv \
 jtag_mux.sv \
 padring.sv \
 padctrl.sv \
-pinmux.sv \
 rv_timer_reg_top.sv \
 rv_timer.sv \
 usbdev_reg_top.sv \
@@ -313,6 +311,8 @@ spi_device.sv \
 sha2.sv \
 prim_filter.sv \
 pinmux_wkup.sv \
+pinmux_reg_top.sv \
+pinmux.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -444,8 +444,8 @@ ${UHDM_file}: ${SV2V_FILE}
 			-top uart \
 			-top spi_device \
 			-top sha2 \
-			-top pinmux_wkup \
 			-top usbdev_flop_2syncpulse \
+			-top pinmux \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})


### PR DESCRIPTION
``pinmux`` and ``pinmux_reg_top`` uses array inside of packed struct that is currently not supported by yosys, so it was replaced with code generated by sv2v.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>