### PR TITLE
Move usbdev modules to uhdm

### DIFF
--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -1792,6 +1792,7483 @@ index 9889b0a1f..9b297e67f 100644
    always_ff @(posedge clk_i or negedge rst_ni) begin
      if (!rst_ni) begin
        d_sync_q <= '0;
+diff --git a/hw/ip/usbdev/rtl/usbdev_reg_top.sv b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+index 4cff2c116..50b7bb01c 100644
+--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
++++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+@@ -19,15 +19,15 @@ module usbdev_reg_top (
+   input  tlul_pkg::tl_d2h_t tl_win_i  [1],
+ 
+   // To HW
+-  output usbdev_reg_pkg::usbdev_reg2hw_t reg2hw, // Write
+-  input  usbdev_reg_pkg::usbdev_hw2reg_t hw2reg, // Read
++  //output usbdev_reg_pkg::usbdev_reg2hw_t reg2hw, // Write
++  //input  usbdev_reg_pkg::usbdev_hw2reg_t hw2reg, // Read
++  output wire [345:0] reg2hw,
++  input wire [176:0] hw2reg,
+ 
+   // Config
+   input devmode_i // If 1, explicit error return for unmapped register access
+ );
+ 
+-  import usbdev_reg_pkg::* ;
+-
+   localparam int AW = 12;
+   localparam int DW = 32;
+   localparam int DBW = DW/8;                    // Byte Width
+@@ -647,4714 +647,2720 @@ module usbdev_reg_top (
+   logic phy_config_usb_ref_disable_wd;
+   logic phy_config_usb_ref_disable_we;
+ 
+-  // Register instances
+-  // R[intr_state]: V(False)
+-
+-  //   F[pkt_received]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_pkt_received (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_pkt_received_we),
+-    .wd     (intr_state_pkt_received_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.pkt_received.de),
+-    .d      (hw2reg.intr_state.pkt_received.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.pkt_received.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_pkt_received_qs)
+-  );
+-
+-
+-  //   F[pkt_sent]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_pkt_sent (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_pkt_sent_we),
+-    .wd     (intr_state_pkt_sent_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.pkt_sent.de),
+-    .d      (hw2reg.intr_state.pkt_sent.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.pkt_sent.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_pkt_sent_qs)
+-  );
+-
+-
+-  //   F[disconnected]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_disconnected (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_disconnected_we),
+-    .wd     (intr_state_disconnected_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.disconnected.de),
+-    .d      (hw2reg.intr_state.disconnected.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.disconnected.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_disconnected_qs)
+-  );
+-
+-
+-  //   F[host_lost]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_host_lost (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_host_lost_we),
+-    .wd     (intr_state_host_lost_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.host_lost.de),
+-    .d      (hw2reg.intr_state.host_lost.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.host_lost.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_host_lost_qs)
+-  );
+-
+-
+-  //   F[link_reset]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_link_reset (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_link_reset_we),
+-    .wd     (intr_state_link_reset_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.link_reset.de),
+-    .d      (hw2reg.intr_state.link_reset.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.link_reset.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_link_reset_qs)
+-  );
+-
+-
+-  //   F[link_suspend]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_link_suspend (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_link_suspend_we),
+-    .wd     (intr_state_link_suspend_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.link_suspend.de),
+-    .d      (hw2reg.intr_state.link_suspend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.link_suspend.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_link_suspend_qs)
+-  );
+-
+-
+-  //   F[link_resume]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_link_resume (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_link_resume_we),
+-    .wd     (intr_state_link_resume_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.link_resume.de),
+-    .d      (hw2reg.intr_state.link_resume.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.link_resume.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_link_resume_qs)
+-  );
+-
+-
+-  //   F[av_empty]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_av_empty (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_av_empty_we),
+-    .wd     (intr_state_av_empty_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.av_empty.de),
+-    .d      (hw2reg.intr_state.av_empty.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.av_empty.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_av_empty_qs)
+-  );
+-
+-
+-  //   F[rx_full]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_rx_full (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_rx_full_we),
+-    .wd     (intr_state_rx_full_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.rx_full.de),
+-    .d      (hw2reg.intr_state.rx_full.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.rx_full.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_rx_full_qs)
+-  );
+-
+-
+-  //   F[av_overflow]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_av_overflow (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_av_overflow_we),
+-    .wd     (intr_state_av_overflow_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.av_overflow.de),
+-    .d      (hw2reg.intr_state.av_overflow.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.av_overflow.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_av_overflow_qs)
+-  );
+-
+-
+-  //   F[link_in_err]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_link_in_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_link_in_err_we),
+-    .wd     (intr_state_link_in_err_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.link_in_err.de),
+-    .d      (hw2reg.intr_state.link_in_err.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.link_in_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_link_in_err_qs)
+-  );
+-
+-
+-  //   F[rx_crc_err]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_rx_crc_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_rx_crc_err_we),
+-    .wd     (intr_state_rx_crc_err_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.rx_crc_err.de),
+-    .d      (hw2reg.intr_state.rx_crc_err.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.rx_crc_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_rx_crc_err_qs)
+-  );
+-
+-
+-  //   F[rx_pid_err]: 12:12
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_rx_pid_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_rx_pid_err_we),
+-    .wd     (intr_state_rx_pid_err_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.rx_pid_err.de),
+-    .d      (hw2reg.intr_state.rx_pid_err.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.rx_pid_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_rx_pid_err_qs)
+-  );
+-
+-
+-  //   F[rx_bitstuff_err]: 13:13
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_rx_bitstuff_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_rx_bitstuff_err_we),
+-    .wd     (intr_state_rx_bitstuff_err_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.rx_bitstuff_err.de),
+-    .d      (hw2reg.intr_state.rx_bitstuff_err.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.rx_bitstuff_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_rx_bitstuff_err_qs)
+-  );
+-
+-
+-  //   F[frame]: 14:14
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_frame (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_frame_we),
+-    .wd     (intr_state_frame_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.frame.de),
+-    .d      (hw2reg.intr_state.frame.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.frame.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_frame_qs)
+-  );
+-
+-
+-  //   F[connected]: 15:15
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_state_connected (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_state_connected_we),
+-    .wd     (intr_state_connected_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.intr_state.connected.de),
+-    .d      (hw2reg.intr_state.connected.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_state.connected.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_state_connected_qs)
+-  );
+-
+-
+-  // R[intr_enable]: V(False)
+-
+-  //   F[pkt_received]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_pkt_received (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_pkt_received_we),
+-    .wd     (intr_enable_pkt_received_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.pkt_received.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_pkt_received_qs)
+-  );
+-
+-
+-  //   F[pkt_sent]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_pkt_sent (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_pkt_sent_we),
+-    .wd     (intr_enable_pkt_sent_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.pkt_sent.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_pkt_sent_qs)
+-  );
+-
+-
+-  //   F[disconnected]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_disconnected (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_disconnected_we),
+-    .wd     (intr_enable_disconnected_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.disconnected.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_disconnected_qs)
+-  );
+-
+-
+-  //   F[host_lost]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_host_lost (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_host_lost_we),
+-    .wd     (intr_enable_host_lost_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.host_lost.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_host_lost_qs)
+-  );
+-
+-
+-  //   F[link_reset]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_link_reset (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_link_reset_we),
+-    .wd     (intr_enable_link_reset_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.link_reset.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_link_reset_qs)
+-  );
+-
+-
+-  //   F[link_suspend]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_link_suspend (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_link_suspend_we),
+-    .wd     (intr_enable_link_suspend_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.link_suspend.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_link_suspend_qs)
+-  );
+-
+-
+-  //   F[link_resume]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_link_resume (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_link_resume_we),
+-    .wd     (intr_enable_link_resume_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.link_resume.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_link_resume_qs)
+-  );
+-
+-
+-  //   F[av_empty]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_av_empty (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_av_empty_we),
+-    .wd     (intr_enable_av_empty_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.av_empty.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_av_empty_qs)
+-  );
+-
+-
+-  //   F[rx_full]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_rx_full (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_rx_full_we),
+-    .wd     (intr_enable_rx_full_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.rx_full.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_rx_full_qs)
+-  );
+-
+-
+-  //   F[av_overflow]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_av_overflow (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_av_overflow_we),
+-    .wd     (intr_enable_av_overflow_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.av_overflow.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_av_overflow_qs)
+-  );
+-
+-
+-  //   F[link_in_err]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_link_in_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_link_in_err_we),
+-    .wd     (intr_enable_link_in_err_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.link_in_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_link_in_err_qs)
+-  );
+-
+-
+-  //   F[rx_crc_err]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_rx_crc_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_rx_crc_err_we),
+-    .wd     (intr_enable_rx_crc_err_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.rx_crc_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_rx_crc_err_qs)
+-  );
+-
+-
+-  //   F[rx_pid_err]: 12:12
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_rx_pid_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_rx_pid_err_we),
+-    .wd     (intr_enable_rx_pid_err_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.rx_pid_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_rx_pid_err_qs)
+-  );
+-
+-
+-  //   F[rx_bitstuff_err]: 13:13
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_rx_bitstuff_err (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_rx_bitstuff_err_we),
+-    .wd     (intr_enable_rx_bitstuff_err_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.rx_bitstuff_err.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_rx_bitstuff_err_qs)
+-  );
+-
+-
+-  //   F[frame]: 14:14
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_frame (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_frame_we),
+-    .wd     (intr_enable_frame_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.frame.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_frame_qs)
+-  );
+-
+-
+-  //   F[connected]: 15:15
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_intr_enable_connected (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (intr_enable_connected_we),
+-    .wd     (intr_enable_connected_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.intr_enable.connected.q ),
+-
+-    // to register interface (read)
+-    .qs     (intr_enable_connected_qs)
+-  );
+-
+-
+-  // R[intr_test]: V(True)
+-
+-  //   F[pkt_received]: 0:0
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_pkt_received (
+-    .re     (1'b0),
+-    .we     (intr_test_pkt_received_we),
+-    .wd     (intr_test_pkt_received_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.pkt_received.qe),
+-    .q      (reg2hw.intr_test.pkt_received.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[pkt_sent]: 1:1
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_pkt_sent (
+-    .re     (1'b0),
+-    .we     (intr_test_pkt_sent_we),
+-    .wd     (intr_test_pkt_sent_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.pkt_sent.qe),
+-    .q      (reg2hw.intr_test.pkt_sent.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[disconnected]: 2:2
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_disconnected (
+-    .re     (1'b0),
+-    .we     (intr_test_disconnected_we),
+-    .wd     (intr_test_disconnected_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.disconnected.qe),
+-    .q      (reg2hw.intr_test.disconnected.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[host_lost]: 3:3
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_host_lost (
+-    .re     (1'b0),
+-    .we     (intr_test_host_lost_we),
+-    .wd     (intr_test_host_lost_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.host_lost.qe),
+-    .q      (reg2hw.intr_test.host_lost.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[link_reset]: 4:4
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_link_reset (
+-    .re     (1'b0),
+-    .we     (intr_test_link_reset_we),
+-    .wd     (intr_test_link_reset_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.link_reset.qe),
+-    .q      (reg2hw.intr_test.link_reset.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[link_suspend]: 5:5
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_link_suspend (
+-    .re     (1'b0),
+-    .we     (intr_test_link_suspend_we),
+-    .wd     (intr_test_link_suspend_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.link_suspend.qe),
+-    .q      (reg2hw.intr_test.link_suspend.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[link_resume]: 6:6
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_link_resume (
+-    .re     (1'b0),
+-    .we     (intr_test_link_resume_we),
+-    .wd     (intr_test_link_resume_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.link_resume.qe),
+-    .q      (reg2hw.intr_test.link_resume.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[av_empty]: 7:7
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_av_empty (
+-    .re     (1'b0),
+-    .we     (intr_test_av_empty_we),
+-    .wd     (intr_test_av_empty_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.av_empty.qe),
+-    .q      (reg2hw.intr_test.av_empty.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[rx_full]: 8:8
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_rx_full (
+-    .re     (1'b0),
+-    .we     (intr_test_rx_full_we),
+-    .wd     (intr_test_rx_full_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.rx_full.qe),
+-    .q      (reg2hw.intr_test.rx_full.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[av_overflow]: 9:9
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_av_overflow (
+-    .re     (1'b0),
+-    .we     (intr_test_av_overflow_we),
+-    .wd     (intr_test_av_overflow_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.av_overflow.qe),
+-    .q      (reg2hw.intr_test.av_overflow.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[link_in_err]: 10:10
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_link_in_err (
+-    .re     (1'b0),
+-    .we     (intr_test_link_in_err_we),
+-    .wd     (intr_test_link_in_err_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.link_in_err.qe),
+-    .q      (reg2hw.intr_test.link_in_err.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[rx_crc_err]: 11:11
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_rx_crc_err (
+-    .re     (1'b0),
+-    .we     (intr_test_rx_crc_err_we),
+-    .wd     (intr_test_rx_crc_err_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.rx_crc_err.qe),
+-    .q      (reg2hw.intr_test.rx_crc_err.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[rx_pid_err]: 12:12
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_rx_pid_err (
+-    .re     (1'b0),
+-    .we     (intr_test_rx_pid_err_we),
+-    .wd     (intr_test_rx_pid_err_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.rx_pid_err.qe),
+-    .q      (reg2hw.intr_test.rx_pid_err.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[rx_bitstuff_err]: 13:13
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_rx_bitstuff_err (
+-    .re     (1'b0),
+-    .we     (intr_test_rx_bitstuff_err_we),
+-    .wd     (intr_test_rx_bitstuff_err_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.rx_bitstuff_err.qe),
+-    .q      (reg2hw.intr_test.rx_bitstuff_err.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[frame]: 14:14
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_frame (
+-    .re     (1'b0),
+-    .we     (intr_test_frame_we),
+-    .wd     (intr_test_frame_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.frame.qe),
+-    .q      (reg2hw.intr_test.frame.q ),
+-    .qs     ()
+-  );
+-
+-
+-  //   F[connected]: 15:15
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_intr_test_connected (
+-    .re     (1'b0),
+-    .we     (intr_test_connected_we),
+-    .wd     (intr_test_connected_wd),
+-    .d      ('0),
+-    .qre    (),
+-    .qe     (reg2hw.intr_test.connected.qe),
+-    .q      (reg2hw.intr_test.connected.q ),
+-    .qs     ()
+-  );
+-
+-
+-  // R[usbctrl]: V(False)
+-
+-  //   F[enable]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_usbctrl_enable (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (usbctrl_enable_we),
+-    .wd     (usbctrl_enable_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.usbctrl.enable.q ),
+-
+-    // to register interface (read)
+-    .qs     (usbctrl_enable_qs)
+-  );
+-
+-
+-  //   F[device_address]: 22:16
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_usbctrl_device_address (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (usbctrl_device_address_we),
+-    .wd     (usbctrl_device_address_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.usbctrl.device_address.de),
+-    .d      (hw2reg.usbctrl.device_address.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.usbctrl.device_address.q ),
+-
+-    // to register interface (read)
+-    .qs     (usbctrl_device_address_qs)
+-  );
+-
+-
+-  // R[usbstat]: V(True)
+-
+-  //   F[frame]: 10:0
+-  prim_subreg_ext #(
+-    .DW    (11)
+-  ) u_usbstat_frame (
+-    .re     (usbstat_frame_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.frame.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_frame_qs)
+-  );
+-
+-
+-  //   F[host_lost]: 11:11
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_usbstat_host_lost (
+-    .re     (usbstat_host_lost_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.host_lost.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_host_lost_qs)
+-  );
+-
+-
+-  //   F[link_state]: 14:12
+-  prim_subreg_ext #(
+-    .DW    (3)
+-  ) u_usbstat_link_state (
+-    .re     (usbstat_link_state_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.link_state.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_link_state_qs)
+-  );
+-
+-
+-  //   F[sense]: 15:15
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_usbstat_sense (
+-    .re     (usbstat_sense_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.sense.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_sense_qs)
+-  );
+-
+-
+-  //   F[av_depth]: 18:16
+-  prim_subreg_ext #(
+-    .DW    (3)
+-  ) u_usbstat_av_depth (
+-    .re     (usbstat_av_depth_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.av_depth.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_av_depth_qs)
+-  );
+-
+-
+-  //   F[av_full]: 23:23
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_usbstat_av_full (
+-    .re     (usbstat_av_full_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.av_full.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_av_full_qs)
+-  );
+-
+-
+-  //   F[rx_depth]: 26:24
+-  prim_subreg_ext #(
+-    .DW    (3)
+-  ) u_usbstat_rx_depth (
+-    .re     (usbstat_rx_depth_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.rx_depth.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_rx_depth_qs)
+-  );
+-
+-
+-  //   F[rx_empty]: 31:31
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_usbstat_rx_empty (
+-    .re     (usbstat_rx_empty_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.usbstat.rx_empty.d),
+-    .qre    (),
+-    .qe     (),
+-    .q      (),
+-    .qs     (usbstat_rx_empty_qs)
+-  );
+-
+-
+-  // R[avbuffer]: V(False)
+-
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("WO"),
+-    .RESVAL  (5'h0)
+-  ) u_avbuffer (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (avbuffer_we),
+-    .wd     (avbuffer_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.avbuffer.qe),
+-    .q      (reg2hw.avbuffer.q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // R[rxfifo]: V(True)
+-
+-  //   F[buffer]: 4:0
+-  prim_subreg_ext #(
+-    .DW    (5)
+-  ) u_rxfifo_buffer (
+-    .re     (rxfifo_buffer_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.rxfifo.buffer.d),
+-    .qre    (reg2hw.rxfifo.buffer.re),
+-    .qe     (),
+-    .q      (reg2hw.rxfifo.buffer.q ),
+-    .qs     (rxfifo_buffer_qs)
+-  );
+-
+-
+-  //   F[size]: 14:8
+-  prim_subreg_ext #(
+-    .DW    (7)
+-  ) u_rxfifo_size (
+-    .re     (rxfifo_size_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.rxfifo.size.d),
+-    .qre    (reg2hw.rxfifo.size.re),
+-    .qe     (),
+-    .q      (reg2hw.rxfifo.size.q ),
+-    .qs     (rxfifo_size_qs)
+-  );
+-
+-
+-  //   F[setup]: 19:19
+-  prim_subreg_ext #(
+-    .DW    (1)
+-  ) u_rxfifo_setup (
+-    .re     (rxfifo_setup_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.rxfifo.setup.d),
+-    .qre    (reg2hw.rxfifo.setup.re),
+-    .qe     (),
+-    .q      (reg2hw.rxfifo.setup.q ),
+-    .qs     (rxfifo_setup_qs)
+-  );
+-
+-
+-  //   F[ep]: 23:20
+-  prim_subreg_ext #(
+-    .DW    (4)
+-  ) u_rxfifo_ep (
+-    .re     (rxfifo_ep_re),
+-    .we     (1'b0),
+-    .wd     ('0),
+-    .d      (hw2reg.rxfifo.ep.d),
+-    .qre    (reg2hw.rxfifo.ep.re),
+-    .qe     (),
+-    .q      (reg2hw.rxfifo.ep.q ),
+-    .qs     (rxfifo_ep_qs)
+-  );
+-
+-
+-
+-  // Subregister 0 of Multireg rxenable_setup
+-  // R[rxenable_setup]: V(False)
+-
+-  // F[setup0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup0_we),
+-    .wd     (rxenable_setup_setup0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup0_qs)
+-  );
+-
+-
+-  // F[setup1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup1_we),
+-    .wd     (rxenable_setup_setup1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup1_qs)
+-  );
+-
+-
+-  // F[setup2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup2_we),
+-    .wd     (rxenable_setup_setup2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup2_qs)
+-  );
+-
+-
+-  // F[setup3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup3_we),
+-    .wd     (rxenable_setup_setup3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup3_qs)
+-  );
+-
+-
+-  // F[setup4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup4_we),
+-    .wd     (rxenable_setup_setup4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup4_qs)
+-  );
+-
+-
+-  // F[setup5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup5_we),
+-    .wd     (rxenable_setup_setup5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup5_qs)
+-  );
+-
+-
+-  // F[setup6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup6_we),
+-    .wd     (rxenable_setup_setup6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup6_qs)
+-  );
+-
+-
+-  // F[setup7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup7_we),
+-    .wd     (rxenable_setup_setup7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup7_qs)
+-  );
+-
+-
+-  // F[setup8]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup8_we),
+-    .wd     (rxenable_setup_setup8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup8_qs)
+-  );
+-
+-
+-  // F[setup9]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup9_we),
+-    .wd     (rxenable_setup_setup9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup9_qs)
+-  );
+-
+-
+-  // F[setup10]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup10_we),
+-    .wd     (rxenable_setup_setup10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup10_qs)
+-  );
+-
+-
+-  // F[setup11]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_setup_setup11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_setup_setup11_we),
+-    .wd     (rxenable_setup_setup11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_setup[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_setup_setup11_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg rxenable_out
+-  // R[rxenable_out]: V(False)
+-
+-  // F[out0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out0_we),
+-    .wd     (rxenable_out_out0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out0_qs)
+-  );
+-
+-
+-  // F[out1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out1_we),
+-    .wd     (rxenable_out_out1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out1_qs)
+-  );
+-
+-
+-  // F[out2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out2_we),
+-    .wd     (rxenable_out_out2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out2_qs)
+-  );
+-
+-
+-  // F[out3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out3_we),
+-    .wd     (rxenable_out_out3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out3_qs)
+-  );
+-
+-
+-  // F[out4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out4_we),
+-    .wd     (rxenable_out_out4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out4_qs)
+-  );
+-
+-
+-  // F[out5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out5_we),
+-    .wd     (rxenable_out_out5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out5_qs)
+-  );
+-
+-
+-  // F[out6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out6_we),
+-    .wd     (rxenable_out_out6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out6_qs)
+-  );
+-
+-
+-  // F[out7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out7_we),
+-    .wd     (rxenable_out_out7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out7_qs)
+-  );
+-
+-
+-  // F[out8]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out8_we),
+-    .wd     (rxenable_out_out8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out8_qs)
+-  );
+-
+-
+-  // F[out9]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out9_we),
+-    .wd     (rxenable_out_out9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out9_qs)
+-  );
+-
+-
+-  // F[out10]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out10_we),
+-    .wd     (rxenable_out_out10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out10_qs)
+-  );
+-
+-
+-  // F[out11]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_rxenable_out_out11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (rxenable_out_out11_we),
+-    .wd     (rxenable_out_out11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.rxenable_out[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (rxenable_out_out11_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg in_sent
+-  // R[in_sent]: V(False)
+-
+-  // F[sent0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent0_we),
+-    .wd     (in_sent_sent0_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[0].de),
+-    .d      (hw2reg.in_sent[0].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent0_qs)
+-  );
+-
+-
+-  // F[sent1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent1_we),
+-    .wd     (in_sent_sent1_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[1].de),
+-    .d      (hw2reg.in_sent[1].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent1_qs)
+-  );
+-
+-
+-  // F[sent2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent2_we),
+-    .wd     (in_sent_sent2_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[2].de),
+-    .d      (hw2reg.in_sent[2].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent2_qs)
+-  );
+-
+-
+-  // F[sent3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent3_we),
+-    .wd     (in_sent_sent3_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[3].de),
+-    .d      (hw2reg.in_sent[3].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent3_qs)
+-  );
+-
+-
+-  // F[sent4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent4_we),
+-    .wd     (in_sent_sent4_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[4].de),
+-    .d      (hw2reg.in_sent[4].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent4_qs)
+-  );
+-
+-
+-  // F[sent5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent5_we),
+-    .wd     (in_sent_sent5_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[5].de),
+-    .d      (hw2reg.in_sent[5].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent5_qs)
+-  );
+-
+-
+-  // F[sent6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent6_we),
+-    .wd     (in_sent_sent6_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[6].de),
+-    .d      (hw2reg.in_sent[6].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent6_qs)
+-  );
+-
+-
+-  // F[sent7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent7_we),
+-    .wd     (in_sent_sent7_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[7].de),
+-    .d      (hw2reg.in_sent[7].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent7_qs)
+-  );
+-
+-
+-  // F[sent8]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent8_we),
+-    .wd     (in_sent_sent8_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[8].de),
+-    .d      (hw2reg.in_sent[8].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent8_qs)
+-  );
+-
+-
+-  // F[sent9]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent9_we),
+-    .wd     (in_sent_sent9_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[9].de),
+-    .d      (hw2reg.in_sent[9].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent9_qs)
+-  );
+-
+-
+-  // F[sent10]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent10_we),
+-    .wd     (in_sent_sent10_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[10].de),
+-    .d      (hw2reg.in_sent[10].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent10_qs)
+-  );
+-
+-
+-  // F[sent11]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_in_sent_sent11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (in_sent_sent11_we),
+-    .wd     (in_sent_sent11_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.in_sent[11].de),
+-    .d      (hw2reg.in_sent[11].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (),
+-
+-    // to register interface (read)
+-    .qs     (in_sent_sent11_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg stall
+-  // R[stall]: V(False)
+-
+-  // F[stall0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall0_we),
+-    .wd     (stall_stall0_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[0].de),
+-    .d      (hw2reg.stall[0].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall0_qs)
+-  );
+-
+-
+-  // F[stall1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall1_we),
+-    .wd     (stall_stall1_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[1].de),
+-    .d      (hw2reg.stall[1].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall1_qs)
+-  );
+-
+-
+-  // F[stall2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall2_we),
+-    .wd     (stall_stall2_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[2].de),
+-    .d      (hw2reg.stall[2].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall2_qs)
+-  );
+-
+-
+-  // F[stall3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall3_we),
+-    .wd     (stall_stall3_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[3].de),
+-    .d      (hw2reg.stall[3].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall3_qs)
+-  );
+-
+-
+-  // F[stall4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall4_we),
+-    .wd     (stall_stall4_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[4].de),
+-    .d      (hw2reg.stall[4].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall4_qs)
+-  );
+-
+-
+-  // F[stall5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall5_we),
+-    .wd     (stall_stall5_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[5].de),
+-    .d      (hw2reg.stall[5].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall5_qs)
+-  );
+-
+-
+-  // F[stall6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall6_we),
+-    .wd     (stall_stall6_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[6].de),
+-    .d      (hw2reg.stall[6].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall6_qs)
+-  );
+-
+-
+-  // F[stall7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall7_we),
+-    .wd     (stall_stall7_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[7].de),
+-    .d      (hw2reg.stall[7].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall7_qs)
+-  );
+-
+-
+-  // F[stall8]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall8_we),
+-    .wd     (stall_stall8_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[8].de),
+-    .d      (hw2reg.stall[8].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall8_qs)
+-  );
+-
+-
+-  // F[stall9]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall9_we),
+-    .wd     (stall_stall9_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[9].de),
+-    .d      (hw2reg.stall[9].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall9_qs)
+-  );
+-
+-
+-  // F[stall10]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall10_we),
+-    .wd     (stall_stall10_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[10].de),
+-    .d      (hw2reg.stall[10].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall10_qs)
+-  );
+-
+-
+-  // F[stall11]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_stall_stall11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (stall_stall11_we),
+-    .wd     (stall_stall11_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.stall[11].de),
+-    .d      (hw2reg.stall[11].d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.stall[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (stall_stall11_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg configin
+-  // R[configin0]: V(False)
+-
+-  // F[buffer0]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin0_buffer0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin0_buffer0_we),
+-    .wd     (configin0_buffer0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[0].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin0_buffer0_qs)
+-  );
+-
+-
+-  // F[size0]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin0_size0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin0_size0_we),
+-    .wd     (configin0_size0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[0].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin0_size0_qs)
+-  );
+-
+-
+-  // F[pend0]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin0_pend0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin0_pend0_we),
+-    .wd     (configin0_pend0_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[0].pend.de),
+-    .d      (hw2reg.configin[0].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[0].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin0_pend0_qs)
+-  );
+-
+-
+-  // F[rdy0]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin0_rdy0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin0_rdy0_we),
+-    .wd     (configin0_rdy0_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[0].rdy.de),
+-    .d      (hw2reg.configin[0].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[0].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin0_rdy0_qs)
+-  );
+-
+-
+-  // Subregister 1 of Multireg configin
+-  // R[configin1]: V(False)
+-
+-  // F[buffer1]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin1_buffer1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin1_buffer1_we),
+-    .wd     (configin1_buffer1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[1].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin1_buffer1_qs)
+-  );
+-
+-
+-  // F[size1]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin1_size1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin1_size1_we),
+-    .wd     (configin1_size1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[1].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin1_size1_qs)
+-  );
+-
+-
+-  // F[pend1]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin1_pend1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin1_pend1_we),
+-    .wd     (configin1_pend1_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[1].pend.de),
+-    .d      (hw2reg.configin[1].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[1].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin1_pend1_qs)
+-  );
+-
+-
+-  // F[rdy1]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin1_rdy1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin1_rdy1_we),
+-    .wd     (configin1_rdy1_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[1].rdy.de),
+-    .d      (hw2reg.configin[1].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[1].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin1_rdy1_qs)
+-  );
+-
+-
+-  // Subregister 2 of Multireg configin
+-  // R[configin2]: V(False)
+-
+-  // F[buffer2]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin2_buffer2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin2_buffer2_we),
+-    .wd     (configin2_buffer2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[2].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin2_buffer2_qs)
+-  );
+-
+-
+-  // F[size2]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin2_size2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin2_size2_we),
+-    .wd     (configin2_size2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[2].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin2_size2_qs)
+-  );
+-
+-
+-  // F[pend2]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin2_pend2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin2_pend2_we),
+-    .wd     (configin2_pend2_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[2].pend.de),
+-    .d      (hw2reg.configin[2].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[2].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin2_pend2_qs)
+-  );
+-
+-
+-  // F[rdy2]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin2_rdy2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin2_rdy2_we),
+-    .wd     (configin2_rdy2_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[2].rdy.de),
+-    .d      (hw2reg.configin[2].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[2].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin2_rdy2_qs)
+-  );
+-
+-
+-  // Subregister 3 of Multireg configin
+-  // R[configin3]: V(False)
+-
+-  // F[buffer3]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin3_buffer3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin3_buffer3_we),
+-    .wd     (configin3_buffer3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[3].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin3_buffer3_qs)
+-  );
+-
+-
+-  // F[size3]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin3_size3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin3_size3_we),
+-    .wd     (configin3_size3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[3].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin3_size3_qs)
+-  );
+-
+-
+-  // F[pend3]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin3_pend3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin3_pend3_we),
+-    .wd     (configin3_pend3_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[3].pend.de),
+-    .d      (hw2reg.configin[3].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[3].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin3_pend3_qs)
+-  );
+-
+-
+-  // F[rdy3]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin3_rdy3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin3_rdy3_we),
+-    .wd     (configin3_rdy3_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[3].rdy.de),
+-    .d      (hw2reg.configin[3].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[3].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin3_rdy3_qs)
+-  );
+-
+-
+-  // Subregister 4 of Multireg configin
+-  // R[configin4]: V(False)
+-
+-  // F[buffer4]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin4_buffer4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin4_buffer4_we),
+-    .wd     (configin4_buffer4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[4].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin4_buffer4_qs)
+-  );
+-
+-
+-  // F[size4]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin4_size4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin4_size4_we),
+-    .wd     (configin4_size4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[4].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin4_size4_qs)
+-  );
+-
+-
+-  // F[pend4]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin4_pend4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin4_pend4_we),
+-    .wd     (configin4_pend4_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[4].pend.de),
+-    .d      (hw2reg.configin[4].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[4].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin4_pend4_qs)
+-  );
+-
+-
+-  // F[rdy4]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin4_rdy4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin4_rdy4_we),
+-    .wd     (configin4_rdy4_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[4].rdy.de),
+-    .d      (hw2reg.configin[4].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[4].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin4_rdy4_qs)
+-  );
+-
+-
+-  // Subregister 5 of Multireg configin
+-  // R[configin5]: V(False)
+-
+-  // F[buffer5]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin5_buffer5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin5_buffer5_we),
+-    .wd     (configin5_buffer5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[5].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin5_buffer5_qs)
+-  );
+-
+-
+-  // F[size5]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin5_size5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin5_size5_we),
+-    .wd     (configin5_size5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[5].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin5_size5_qs)
+-  );
+-
+-
+-  // F[pend5]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin5_pend5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin5_pend5_we),
+-    .wd     (configin5_pend5_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[5].pend.de),
+-    .d      (hw2reg.configin[5].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[5].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin5_pend5_qs)
+-  );
+-
+-
+-  // F[rdy5]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin5_rdy5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin5_rdy5_we),
+-    .wd     (configin5_rdy5_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[5].rdy.de),
+-    .d      (hw2reg.configin[5].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[5].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin5_rdy5_qs)
+-  );
+-
+-
+-  // Subregister 6 of Multireg configin
+-  // R[configin6]: V(False)
+-
+-  // F[buffer6]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin6_buffer6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin6_buffer6_we),
+-    .wd     (configin6_buffer6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[6].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin6_buffer6_qs)
+-  );
+-
+-
+-  // F[size6]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin6_size6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin6_size6_we),
+-    .wd     (configin6_size6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[6].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin6_size6_qs)
+-  );
+-
+-
+-  // F[pend6]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin6_pend6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin6_pend6_we),
+-    .wd     (configin6_pend6_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[6].pend.de),
+-    .d      (hw2reg.configin[6].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[6].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin6_pend6_qs)
+-  );
+-
+-
+-  // F[rdy6]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin6_rdy6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin6_rdy6_we),
+-    .wd     (configin6_rdy6_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[6].rdy.de),
+-    .d      (hw2reg.configin[6].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[6].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin6_rdy6_qs)
+-  );
+-
+-
+-  // Subregister 7 of Multireg configin
+-  // R[configin7]: V(False)
+-
+-  // F[buffer7]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin7_buffer7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin7_buffer7_we),
+-    .wd     (configin7_buffer7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[7].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin7_buffer7_qs)
+-  );
+-
+-
+-  // F[size7]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin7_size7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin7_size7_we),
+-    .wd     (configin7_size7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[7].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin7_size7_qs)
+-  );
+-
+-
+-  // F[pend7]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin7_pend7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin7_pend7_we),
+-    .wd     (configin7_pend7_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[7].pend.de),
+-    .d      (hw2reg.configin[7].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[7].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin7_pend7_qs)
+-  );
+-
+-
+-  // F[rdy7]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin7_rdy7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin7_rdy7_we),
+-    .wd     (configin7_rdy7_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[7].rdy.de),
+-    .d      (hw2reg.configin[7].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[7].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin7_rdy7_qs)
+-  );
+-
+-
+-  // Subregister 8 of Multireg configin
+-  // R[configin8]: V(False)
+-
+-  // F[buffer8]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin8_buffer8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin8_buffer8_we),
+-    .wd     (configin8_buffer8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[8].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin8_buffer8_qs)
+-  );
+-
+-
+-  // F[size8]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin8_size8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin8_size8_we),
+-    .wd     (configin8_size8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[8].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin8_size8_qs)
+-  );
+-
+-
+-  // F[pend8]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin8_pend8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin8_pend8_we),
+-    .wd     (configin8_pend8_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[8].pend.de),
+-    .d      (hw2reg.configin[8].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[8].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin8_pend8_qs)
+-  );
+-
+-
+-  // F[rdy8]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin8_rdy8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin8_rdy8_we),
+-    .wd     (configin8_rdy8_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[8].rdy.de),
+-    .d      (hw2reg.configin[8].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[8].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin8_rdy8_qs)
+-  );
+-
+-
+-  // Subregister 9 of Multireg configin
+-  // R[configin9]: V(False)
+-
+-  // F[buffer9]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin9_buffer9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin9_buffer9_we),
+-    .wd     (configin9_buffer9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[9].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin9_buffer9_qs)
+-  );
+-
+-
+-  // F[size9]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin9_size9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin9_size9_we),
+-    .wd     (configin9_size9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[9].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin9_size9_qs)
+-  );
+-
+-
+-  // F[pend9]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin9_pend9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin9_pend9_we),
+-    .wd     (configin9_pend9_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[9].pend.de),
+-    .d      (hw2reg.configin[9].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[9].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin9_pend9_qs)
+-  );
+-
+-
+-  // F[rdy9]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin9_rdy9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin9_rdy9_we),
+-    .wd     (configin9_rdy9_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[9].rdy.de),
+-    .d      (hw2reg.configin[9].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[9].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin9_rdy9_qs)
+-  );
+-
+-
+-  // Subregister 10 of Multireg configin
+-  // R[configin10]: V(False)
+-
+-  // F[buffer10]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin10_buffer10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin10_buffer10_we),
+-    .wd     (configin10_buffer10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[10].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin10_buffer10_qs)
+-  );
+-
+-
+-  // F[size10]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin10_size10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin10_size10_we),
+-    .wd     (configin10_size10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[10].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin10_size10_qs)
+-  );
+-
+-
+-  // F[pend10]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin10_pend10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin10_pend10_we),
+-    .wd     (configin10_pend10_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[10].pend.de),
+-    .d      (hw2reg.configin[10].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[10].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin10_pend10_qs)
+-  );
+-
+-
+-  // F[rdy10]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin10_rdy10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin10_rdy10_we),
+-    .wd     (configin10_rdy10_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[10].rdy.de),
+-    .d      (hw2reg.configin[10].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[10].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin10_rdy10_qs)
+-  );
+-
+-
+-  // Subregister 11 of Multireg configin
+-  // R[configin11]: V(False)
+-
+-  // F[buffer11]: 4:0
+-  prim_subreg #(
+-    .DW      (5),
+-    .SWACCESS("RW"),
+-    .RESVAL  (5'h0)
+-  ) u_configin11_buffer11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin11_buffer11_we),
+-    .wd     (configin11_buffer11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[11].buffer.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin11_buffer11_qs)
+-  );
+-
+-
+-  // F[size11]: 14:8
+-  prim_subreg #(
+-    .DW      (7),
+-    .SWACCESS("RW"),
+-    .RESVAL  (7'h0)
+-  ) u_configin11_size11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin11_size11_we),
+-    .wd     (configin11_size11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[11].size.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin11_size11_qs)
+-  );
+-
+-
+-  // F[pend11]: 30:30
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("W1C"),
+-    .RESVAL  (1'h0)
+-  ) u_configin11_pend11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin11_pend11_we),
+-    .wd     (configin11_pend11_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[11].pend.de),
+-    .d      (hw2reg.configin[11].pend.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[11].pend.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin11_pend11_qs)
+-  );
+-
+-
+-  // F[rdy11]: 31:31
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_configin11_rdy11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (configin11_rdy11_we),
+-    .wd     (configin11_rdy11_wd),
+-
+-    // from internal hardware
+-    .de     (hw2reg.configin[11].rdy.de),
+-    .d      (hw2reg.configin[11].rdy.d ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.configin[11].rdy.q ),
+-
+-    // to register interface (read)
+-    .qs     (configin11_rdy11_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg iso
+-  // R[iso]: V(False)
+-
+-  // F[iso0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso0_we),
+-    .wd     (iso_iso0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[0].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso0_qs)
+-  );
+-
+-
+-  // F[iso1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso1_we),
+-    .wd     (iso_iso1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[1].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso1_qs)
+-  );
+-
+-
+-  // F[iso2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso2_we),
+-    .wd     (iso_iso2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[2].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso2_qs)
+-  );
+-
+-
+-  // F[iso3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso3_we),
+-    .wd     (iso_iso3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[3].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso3_qs)
+-  );
+-
+-
+-  // F[iso4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso4_we),
+-    .wd     (iso_iso4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[4].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso4_qs)
+-  );
+-
+-
+-  // F[iso5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso5_we),
+-    .wd     (iso_iso5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[5].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso5_qs)
+-  );
+-
+-
+-  // F[iso6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso6_we),
+-    .wd     (iso_iso6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[6].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso6_qs)
+-  );
+-
+-
+-  // F[iso7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso7_we),
+-    .wd     (iso_iso7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[7].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso7_qs)
+-  );
+-
+-
+-  // F[iso8]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso8_we),
+-    .wd     (iso_iso8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[8].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso8_qs)
+-  );
+-
+-
+-  // F[iso9]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso9_we),
+-    .wd     (iso_iso9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[9].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso9_qs)
+-  );
+-
+-
+-  // F[iso10]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso10_we),
+-    .wd     (iso_iso10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[10].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso10_qs)
+-  );
+-
+-
+-  // F[iso11]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_iso_iso11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (iso_iso11_we),
+-    .wd     (iso_iso11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.iso[11].q ),
+-
+-    // to register interface (read)
+-    .qs     (iso_iso11_qs)
+-  );
+-
+-
+-
+-
+-  // Subregister 0 of Multireg data_toggle_clear
+-  // R[data_toggle_clear]: V(False)
+-
+-  // F[clear0]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear0 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear0_we),
+-    .wd     (data_toggle_clear_clear0_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[0].qe),
+-    .q      (reg2hw.data_toggle_clear[0].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear1]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear1 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear1_we),
+-    .wd     (data_toggle_clear_clear1_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[1].qe),
+-    .q      (reg2hw.data_toggle_clear[1].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear2]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear2 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear2_we),
+-    .wd     (data_toggle_clear_clear2_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[2].qe),
+-    .q      (reg2hw.data_toggle_clear[2].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear3]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear3 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear3_we),
+-    .wd     (data_toggle_clear_clear3_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[3].qe),
+-    .q      (reg2hw.data_toggle_clear[3].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear4]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear4 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear4_we),
+-    .wd     (data_toggle_clear_clear4_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[4].qe),
+-    .q      (reg2hw.data_toggle_clear[4].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear5]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear5 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear5_we),
+-    .wd     (data_toggle_clear_clear5_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[5].qe),
+-    .q      (reg2hw.data_toggle_clear[5].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear6]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear6 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear6_we),
+-    .wd     (data_toggle_clear_clear6_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[6].qe),
+-    .q      (reg2hw.data_toggle_clear[6].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear7]: 7:7
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear7 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear7_we),
+-    .wd     (data_toggle_clear_clear7_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[7].qe),
+-    .q      (reg2hw.data_toggle_clear[7].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear8]: 8:8
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear8 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear8_we),
+-    .wd     (data_toggle_clear_clear8_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[8].qe),
+-    .q      (reg2hw.data_toggle_clear[8].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear9]: 9:9
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear9 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear9_we),
+-    .wd     (data_toggle_clear_clear9_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[9].qe),
+-    .q      (reg2hw.data_toggle_clear[9].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear10]: 10:10
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear10 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear10_we),
+-    .wd     (data_toggle_clear_clear10_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[10].qe),
+-    .q      (reg2hw.data_toggle_clear[10].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-  // F[clear11]: 11:11
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("WO"),
+-    .RESVAL  (1'h0)
+-  ) u_data_toggle_clear_clear11 (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (data_toggle_clear_clear11_we),
+-    .wd     (data_toggle_clear_clear11_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (reg2hw.data_toggle_clear[11].qe),
+-    .q      (reg2hw.data_toggle_clear[11].q ),
+-
+-    .qs     ()
+-  );
+-
+-
+-
+-  // R[phy_config]: V(False)
+-
+-  //   F[rx_differential_mode]: 0:0
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_phy_config_rx_differential_mode (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_rx_differential_mode_we),
+-    .wd     (phy_config_rx_differential_mode_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.rx_differential_mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_rx_differential_mode_qs)
+-  );
+-
+-
+-  //   F[tx_differential_mode]: 1:1
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_phy_config_tx_differential_mode (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_tx_differential_mode_we),
+-    .wd     (phy_config_tx_differential_mode_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.tx_differential_mode.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_tx_differential_mode_qs)
+-  );
+-
+-
+-  //   F[eop_single_bit]: 2:2
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h1)
+-  ) u_phy_config_eop_single_bit (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_eop_single_bit_we),
+-    .wd     (phy_config_eop_single_bit_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.eop_single_bit.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_eop_single_bit_qs)
+-  );
+-
+-
+-  //   F[override_pwr_sense_en]: 3:3
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_phy_config_override_pwr_sense_en (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_override_pwr_sense_en_we),
+-    .wd     (phy_config_override_pwr_sense_en_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.override_pwr_sense_en.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_override_pwr_sense_en_qs)
+-  );
+-
+-
+-  //   F[override_pwr_sense_val]: 4:4
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_phy_config_override_pwr_sense_val (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_override_pwr_sense_val_we),
+-    .wd     (phy_config_override_pwr_sense_val_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.override_pwr_sense_val.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_override_pwr_sense_val_qs)
+-  );
+-
+-
+-  //   F[pinflip]: 5:5
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_phy_config_pinflip (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_pinflip_we),
+-    .wd     (phy_config_pinflip_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.pinflip.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_pinflip_qs)
+-  );
+-
+-
+-  //   F[usb_ref_disable]: 6:6
+-  prim_subreg #(
+-    .DW      (1),
+-    .SWACCESS("RW"),
+-    .RESVAL  (1'h0)
+-  ) u_phy_config_usb_ref_disable (
+-    .clk_i   (clk_i    ),
+-    .rst_ni  (rst_ni  ),
+-
+-    // from register interface
+-    .we     (phy_config_usb_ref_disable_we),
+-    .wd     (phy_config_usb_ref_disable_wd),
+-
+-    // from internal hardware
+-    .de     (1'b0),
+-    .d      ('0  ),
+-
+-    // to internal hardware
+-    .qe     (),
+-    .q      (reg2hw.phy_config.usb_ref_disable.q ),
+-
+-    // to register interface (read)
+-    .qs     (phy_config_usb_ref_disable_qs)
+-  );
+-
+-
+-
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_pkt_received(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_pkt_received_we),
++	.wd(intr_state_pkt_received_wd),
++	.de(hw2reg[175]),
++	.d(hw2reg[176]),
++	.qe(),
++	.q(reg2hw[345]),
++	.qs(intr_state_pkt_received_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_pkt_sent(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_pkt_sent_we),
++	.wd(intr_state_pkt_sent_wd),
++	.de(hw2reg[173]),
++	.d(hw2reg[174]),
++	.qe(),
++	.q(reg2hw[344]),
++	.qs(intr_state_pkt_sent_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_disconnected(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_disconnected_we),
++	.wd(intr_state_disconnected_wd),
++	.de(hw2reg[171]),
++	.d(hw2reg[172]),
++	.qe(),
++	.q(reg2hw[343]),
++	.qs(intr_state_disconnected_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_host_lost(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_host_lost_we),
++	.wd(intr_state_host_lost_wd),
++	.de(hw2reg[169]),
++	.d(hw2reg[170]),
++	.qe(),
++	.q(reg2hw[342]),
++	.qs(intr_state_host_lost_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_link_reset(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_link_reset_we),
++	.wd(intr_state_link_reset_wd),
++	.de(hw2reg[167]),
++	.d(hw2reg[168]),
++	.qe(),
++	.q(reg2hw[341]),
++	.qs(intr_state_link_reset_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_link_suspend(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_link_suspend_we),
++	.wd(intr_state_link_suspend_wd),
++	.de(hw2reg[165]),
++	.d(hw2reg[166]),
++	.qe(),
++	.q(reg2hw[340]),
++	.qs(intr_state_link_suspend_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_link_resume(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_link_resume_we),
++	.wd(intr_state_link_resume_wd),
++	.de(hw2reg[163]),
++	.d(hw2reg[164]),
++	.qe(),
++	.q(reg2hw[339]),
++	.qs(intr_state_link_resume_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_av_empty(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_av_empty_we),
++	.wd(intr_state_av_empty_wd),
++	.de(hw2reg[161]),
++	.d(hw2reg[162]),
++	.qe(),
++	.q(reg2hw[338]),
++	.qs(intr_state_av_empty_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_rx_full(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_rx_full_we),
++	.wd(intr_state_rx_full_wd),
++	.de(hw2reg[159]),
++	.d(hw2reg[160]),
++	.qe(),
++	.q(reg2hw[337]),
++	.qs(intr_state_rx_full_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_av_overflow(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_av_overflow_we),
++	.wd(intr_state_av_overflow_wd),
++	.de(hw2reg[157]),
++	.d(hw2reg[158]),
++	.qe(),
++	.q(reg2hw[336]),
++	.qs(intr_state_av_overflow_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_link_in_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_link_in_err_we),
++	.wd(intr_state_link_in_err_wd),
++	.de(hw2reg[155]),
++	.d(hw2reg[156]),
++	.qe(),
++	.q(reg2hw[335]),
++	.qs(intr_state_link_in_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_rx_crc_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_rx_crc_err_we),
++	.wd(intr_state_rx_crc_err_wd),
++	.de(hw2reg[153]),
++	.d(hw2reg[154]),
++	.qe(),
++	.q(reg2hw[334]),
++	.qs(intr_state_rx_crc_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_rx_pid_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_rx_pid_err_we),
++	.wd(intr_state_rx_pid_err_wd),
++	.de(hw2reg[151]),
++	.d(hw2reg[152]),
++	.qe(),
++	.q(reg2hw[333]),
++	.qs(intr_state_rx_pid_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_rx_bitstuff_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_rx_bitstuff_err_we),
++	.wd(intr_state_rx_bitstuff_err_wd),
++	.de(hw2reg[149]),
++	.d(hw2reg[150]),
++	.qe(),
++	.q(reg2hw[332]),
++	.qs(intr_state_rx_bitstuff_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_frame(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_frame_we),
++	.wd(intr_state_frame_wd),
++	.de(hw2reg[147]),
++	.d(hw2reg[148]),
++	.qe(),
++	.q(reg2hw[331]),
++	.qs(intr_state_frame_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_intr_state_connected(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_state_connected_we),
++	.wd(intr_state_connected_wd),
++	.de(hw2reg[145]),
++	.d(hw2reg[146]),
++	.qe(),
++	.q(reg2hw[330]),
++	.qs(intr_state_connected_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_pkt_received(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_pkt_received_we),
++	.wd(intr_enable_pkt_received_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[329]),
++	.qs(intr_enable_pkt_received_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_pkt_sent(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_pkt_sent_we),
++	.wd(intr_enable_pkt_sent_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[328]),
++	.qs(intr_enable_pkt_sent_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_disconnected(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_disconnected_we),
++	.wd(intr_enable_disconnected_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[327]),
++	.qs(intr_enable_disconnected_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_host_lost(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_host_lost_we),
++	.wd(intr_enable_host_lost_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[326]),
++	.qs(intr_enable_host_lost_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_link_reset(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_link_reset_we),
++	.wd(intr_enable_link_reset_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[325]),
++	.qs(intr_enable_link_reset_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_link_suspend(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_link_suspend_we),
++	.wd(intr_enable_link_suspend_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[324]),
++	.qs(intr_enable_link_suspend_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_link_resume(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_link_resume_we),
++	.wd(intr_enable_link_resume_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[323]),
++	.qs(intr_enable_link_resume_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_av_empty(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_av_empty_we),
++	.wd(intr_enable_av_empty_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[322]),
++	.qs(intr_enable_av_empty_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_rx_full(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_rx_full_we),
++	.wd(intr_enable_rx_full_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[321]),
++	.qs(intr_enable_rx_full_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_av_overflow(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_av_overflow_we),
++	.wd(intr_enable_av_overflow_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[320]),
++	.qs(intr_enable_av_overflow_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_link_in_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_link_in_err_we),
++	.wd(intr_enable_link_in_err_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[319]),
++	.qs(intr_enable_link_in_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_rx_crc_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_rx_crc_err_we),
++	.wd(intr_enable_rx_crc_err_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[318]),
++	.qs(intr_enable_rx_crc_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_rx_pid_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_rx_pid_err_we),
++	.wd(intr_enable_rx_pid_err_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[317]),
++	.qs(intr_enable_rx_pid_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_rx_bitstuff_err(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_rx_bitstuff_err_we),
++	.wd(intr_enable_rx_bitstuff_err_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[316]),
++	.qs(intr_enable_rx_bitstuff_err_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_frame(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_frame_we),
++	.wd(intr_enable_frame_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[315]),
++	.qs(intr_enable_frame_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_intr_enable_connected(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(intr_enable_connected_we),
++	.wd(intr_enable_connected_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[314]),
++	.qs(intr_enable_connected_qs)
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_pkt_received(
++	.re(1'b0),
++	.we(intr_test_pkt_received_we),
++	.wd(intr_test_pkt_received_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[312]),
++	.q(reg2hw[313]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_pkt_sent(
++	.re(1'b0),
++	.we(intr_test_pkt_sent_we),
++	.wd(intr_test_pkt_sent_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[310]),
++	.q(reg2hw[311]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_disconnected(
++	.re(1'b0),
++	.we(intr_test_disconnected_we),
++	.wd(intr_test_disconnected_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[308]),
++	.q(reg2hw[309]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_host_lost(
++	.re(1'b0),
++	.we(intr_test_host_lost_we),
++	.wd(intr_test_host_lost_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[306]),
++	.q(reg2hw[307]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_link_reset(
++	.re(1'b0),
++	.we(intr_test_link_reset_we),
++	.wd(intr_test_link_reset_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[304]),
++	.q(reg2hw[305]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_link_suspend(
++	.re(1'b0),
++	.we(intr_test_link_suspend_we),
++	.wd(intr_test_link_suspend_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[302]),
++	.q(reg2hw[303]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_link_resume(
++	.re(1'b0),
++	.we(intr_test_link_resume_we),
++	.wd(intr_test_link_resume_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[300]),
++	.q(reg2hw[301]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_av_empty(
++	.re(1'b0),
++	.we(intr_test_av_empty_we),
++	.wd(intr_test_av_empty_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[298]),
++	.q(reg2hw[299]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_rx_full(
++	.re(1'b0),
++	.we(intr_test_rx_full_we),
++	.wd(intr_test_rx_full_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[296]),
++	.q(reg2hw[297]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_av_overflow(
++	.re(1'b0),
++	.we(intr_test_av_overflow_we),
++	.wd(intr_test_av_overflow_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[294]),
++	.q(reg2hw[295]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_link_in_err(
++	.re(1'b0),
++	.we(intr_test_link_in_err_we),
++	.wd(intr_test_link_in_err_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[292]),
++	.q(reg2hw[293]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_rx_crc_err(
++	.re(1'b0),
++	.we(intr_test_rx_crc_err_we),
++	.wd(intr_test_rx_crc_err_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[290]),
++	.q(reg2hw[291]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_rx_pid_err(
++	.re(1'b0),
++	.we(intr_test_rx_pid_err_we),
++	.wd(intr_test_rx_pid_err_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[288]),
++	.q(reg2hw[289]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_rx_bitstuff_err(
++	.re(1'b0),
++	.we(intr_test_rx_bitstuff_err_we),
++	.wd(intr_test_rx_bitstuff_err_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[286]),
++	.q(reg2hw[287]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_frame(
++	.re(1'b0),
++	.we(intr_test_frame_we),
++	.wd(intr_test_frame_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[284]),
++	.q(reg2hw[285]),
++	.qs()
++);
++prim_subreg_ext #(.DW(1)) u_intr_test_connected(
++	.re(1'b0),
++	.we(intr_test_connected_we),
++	.wd(intr_test_connected_wd),
++	.d(1'b0),
++	.qre(),
++	.qe(reg2hw[282]),
++	.q(reg2hw[283]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_usbctrl_enable(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(usbctrl_enable_we),
++	.wd(usbctrl_enable_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[281]),
++	.qs(usbctrl_enable_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_usbctrl_device_address(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(usbctrl_device_address_we),
++	.wd(usbctrl_device_address_wd),
++	.de(hw2reg[137]),
++	.d(hw2reg[144-:7]),
++	.qe(),
++	.q(reg2hw[280-:7]),
++	.qs(usbctrl_device_address_qs)
++);
++prim_subreg_ext #(.DW(11)) u_usbstat_frame(
++	.re(usbstat_frame_re),
++	.we(1'b0),
++	.wd({11 {1'b0}}),
++	.d(hw2reg[136-:11]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_frame_qs)
++);
++prim_subreg_ext #(.DW(1)) u_usbstat_host_lost(
++	.re(usbstat_host_lost_re),
++	.we(1'b0),
++	.wd(1'b0),
++	.d(hw2reg[125]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_host_lost_qs)
++);
++prim_subreg_ext #(.DW(3)) u_usbstat_link_state(
++	.re(usbstat_link_state_re),
++	.we(1'b0),
++	.wd({3 {1'b0}}),
++	.d(hw2reg[124-:3]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_link_state_qs)
++);
++prim_subreg_ext #(.DW(1)) u_usbstat_sense(
++	.re(usbstat_sense_re),
++	.we(1'b0),
++	.wd(1'b0),
++	.d(hw2reg[121]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_sense_qs)
++);
++prim_subreg_ext #(.DW(3)) u_usbstat_av_depth(
++	.re(usbstat_av_depth_re),
++	.we(1'b0),
++	.wd({3 {1'b0}}),
++	.d(hw2reg[120-:3]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_av_depth_qs)
++);
++prim_subreg_ext #(.DW(1)) u_usbstat_av_full(
++	.re(usbstat_av_full_re),
++	.we(1'b0),
++	.wd(1'b0),
++	.d(hw2reg[117]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_av_full_qs)
++);
++prim_subreg_ext #(.DW(3)) u_usbstat_rx_depth(
++	.re(usbstat_rx_depth_re),
++	.we(1'b0),
++	.wd({3 {1'b0}}),
++	.d(hw2reg[116-:3]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_rx_depth_qs)
++);
++prim_subreg_ext #(.DW(1)) u_usbstat_rx_empty(
++	.re(usbstat_rx_empty_re),
++	.we(1'b0),
++	.wd(1'b0),
++	.d(hw2reg[113]),
++	.qre(),
++	.qe(),
++	.q(),
++	.qs(usbstat_rx_empty_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("WO"),
++	.RESVAL(5'h00)
++) u_avbuffer(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(avbuffer_we),
++	.wd(avbuffer_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(reg2hw[268]),
++	.q(reg2hw[273-:5]),
++	.qs()
++);
++prim_subreg_ext #(.DW(5)) u_rxfifo_buffer(
++	.re(rxfifo_buffer_re),
++	.we(1'b0),
++	.wd({5 {1'b0}}),
++	.d(hw2reg[112-:5]),
++	.qre(reg2hw[262]),
++	.qe(),
++	.q(reg2hw[267-:5]),
++	.qs(rxfifo_buffer_qs)
++);
++prim_subreg_ext #(.DW(7)) u_rxfifo_size(
++	.re(rxfifo_size_re),
++	.we(1'b0),
++	.wd({7 {1'b0}}),
++	.d(hw2reg[107-:7]),
++	.qre(reg2hw[254]),
++	.qe(),
++	.q(reg2hw[261-:7]),
++	.qs(rxfifo_size_qs)
++);
++prim_subreg_ext #(.DW(1)) u_rxfifo_setup(
++	.re(rxfifo_setup_re),
++	.we(1'b0),
++	.wd(1'b0),
++	.d(hw2reg[100]),
++	.qre(reg2hw[252]),
++	.qe(),
++	.q(reg2hw[253]),
++	.qs(rxfifo_setup_qs)
++);
++prim_subreg_ext #(.DW(4)) u_rxfifo_ep(
++	.re(rxfifo_ep_re),
++	.we(1'b0),
++	.wd({4 {1'b0}}),
++	.d(hw2reg[99-:4]),
++	.qre(reg2hw[247]),
++	.qe(),
++	.q(reg2hw[251-:4]),
++	.qs(rxfifo_ep_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup0_we),
++	.wd(rxenable_setup_setup0_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[235]),
++	.qs(rxenable_setup_setup0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup1_we),
++	.wd(rxenable_setup_setup1_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[236]),
++	.qs(rxenable_setup_setup1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup2_we),
++	.wd(rxenable_setup_setup2_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[237]),
++	.qs(rxenable_setup_setup2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup3_we),
++	.wd(rxenable_setup_setup3_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[238]),
++	.qs(rxenable_setup_setup3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup4_we),
++	.wd(rxenable_setup_setup4_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[239]),
++	.qs(rxenable_setup_setup4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup5_we),
++	.wd(rxenable_setup_setup5_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[240]),
++	.qs(rxenable_setup_setup5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup6_we),
++	.wd(rxenable_setup_setup6_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[241]),
++	.qs(rxenable_setup_setup6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup7_we),
++	.wd(rxenable_setup_setup7_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[242]),
++	.qs(rxenable_setup_setup7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup8_we),
++	.wd(rxenable_setup_setup8_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[243]),
++	.qs(rxenable_setup_setup8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup9_we),
++	.wd(rxenable_setup_setup9_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[244]),
++	.qs(rxenable_setup_setup9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup10_we),
++	.wd(rxenable_setup_setup10_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[245]),
++	.qs(rxenable_setup_setup10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_setup_setup11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_setup_setup11_we),
++	.wd(rxenable_setup_setup11_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[246]),
++	.qs(rxenable_setup_setup11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out0_we),
++	.wd(rxenable_out_out0_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[223]),
++	.qs(rxenable_out_out0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out1_we),
++	.wd(rxenable_out_out1_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[224]),
++	.qs(rxenable_out_out1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out2_we),
++	.wd(rxenable_out_out2_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[225]),
++	.qs(rxenable_out_out2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out3_we),
++	.wd(rxenable_out_out3_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[226]),
++	.qs(rxenable_out_out3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out4_we),
++	.wd(rxenable_out_out4_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[227]),
++	.qs(rxenable_out_out4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out5_we),
++	.wd(rxenable_out_out5_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[228]),
++	.qs(rxenable_out_out5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out6_we),
++	.wd(rxenable_out_out6_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[229]),
++	.qs(rxenable_out_out6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out7_we),
++	.wd(rxenable_out_out7_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[230]),
++	.qs(rxenable_out_out7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out8_we),
++	.wd(rxenable_out_out8_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[231]),
++	.qs(rxenable_out_out8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out9_we),
++	.wd(rxenable_out_out9_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[232]),
++	.qs(rxenable_out_out9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out10_we),
++	.wd(rxenable_out_out10_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[233]),
++	.qs(rxenable_out_out10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_rxenable_out_out11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(rxenable_out_out11_we),
++	.wd(rxenable_out_out11_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[234]),
++	.qs(rxenable_out_out11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent0_we),
++	.wd(in_sent_sent0_wd),
++	.de(hw2reg[72]),
++	.d(hw2reg[73]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent1_we),
++	.wd(in_sent_sent1_wd),
++	.de(hw2reg[74]),
++	.d(hw2reg[75]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent2_we),
++	.wd(in_sent_sent2_wd),
++	.de(hw2reg[76]),
++	.d(hw2reg[77]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent3_we),
++	.wd(in_sent_sent3_wd),
++	.de(hw2reg[78]),
++	.d(hw2reg[79]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent4_we),
++	.wd(in_sent_sent4_wd),
++	.de(hw2reg[80]),
++	.d(hw2reg[81]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent5_we),
++	.wd(in_sent_sent5_wd),
++	.de(hw2reg[82]),
++	.d(hw2reg[83]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent6_we),
++	.wd(in_sent_sent6_wd),
++	.de(hw2reg[84]),
++	.d(hw2reg[85]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent7_we),
++	.wd(in_sent_sent7_wd),
++	.de(hw2reg[86]),
++	.d(hw2reg[87]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent8_we),
++	.wd(in_sent_sent8_wd),
++	.de(hw2reg[88]),
++	.d(hw2reg[89]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent9_we),
++	.wd(in_sent_sent9_wd),
++	.de(hw2reg[90]),
++	.d(hw2reg[91]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent10_we),
++	.wd(in_sent_sent10_wd),
++	.de(hw2reg[92]),
++	.d(hw2reg[93]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_in_sent_sent11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(in_sent_sent11_we),
++	.wd(in_sent_sent11_wd),
++	.de(hw2reg[94]),
++	.d(hw2reg[95]),
++	.qe(),
++	.q(),
++	.qs(in_sent_sent11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall0_we),
++	.wd(stall_stall0_wd),
++	.de(hw2reg[48]),
++	.d(hw2reg[49]),
++	.qe(),
++	.q(reg2hw[211]),
++	.qs(stall_stall0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall1_we),
++	.wd(stall_stall1_wd),
++	.de(hw2reg[50]),
++	.d(hw2reg[51]),
++	.qe(),
++	.q(reg2hw[212]),
++	.qs(stall_stall1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall2_we),
++	.wd(stall_stall2_wd),
++	.de(hw2reg[52]),
++	.d(hw2reg[53]),
++	.qe(),
++	.q(reg2hw[213]),
++	.qs(stall_stall2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall3_we),
++	.wd(stall_stall3_wd),
++	.de(hw2reg[54]),
++	.d(hw2reg[55]),
++	.qe(),
++	.q(reg2hw[214]),
++	.qs(stall_stall3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall4_we),
++	.wd(stall_stall4_wd),
++	.de(hw2reg[56]),
++	.d(hw2reg[57]),
++	.qe(),
++	.q(reg2hw[215]),
++	.qs(stall_stall4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall5_we),
++	.wd(stall_stall5_wd),
++	.de(hw2reg[58]),
++	.d(hw2reg[59]),
++	.qe(),
++	.q(reg2hw[216]),
++	.qs(stall_stall5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall6_we),
++	.wd(stall_stall6_wd),
++	.de(hw2reg[60]),
++	.d(hw2reg[61]),
++	.qe(),
++	.q(reg2hw[217]),
++	.qs(stall_stall6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall7_we),
++	.wd(stall_stall7_wd),
++	.de(hw2reg[62]),
++	.d(hw2reg[63]),
++	.qe(),
++	.q(reg2hw[218]),
++	.qs(stall_stall7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall8_we),
++	.wd(stall_stall8_wd),
++	.de(hw2reg[64]),
++	.d(hw2reg[65]),
++	.qe(),
++	.q(reg2hw[219]),
++	.qs(stall_stall8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall9_we),
++	.wd(stall_stall9_wd),
++	.de(hw2reg[66]),
++	.d(hw2reg[67]),
++	.qe(),
++	.q(reg2hw[220]),
++	.qs(stall_stall9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall10_we),
++	.wd(stall_stall10_wd),
++	.de(hw2reg[68]),
++	.d(hw2reg[69]),
++	.qe(),
++	.q(reg2hw[221]),
++	.qs(stall_stall10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_stall_stall11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(stall_stall11_we),
++	.wd(stall_stall11_wd),
++	.de(hw2reg[70]),
++	.d(hw2reg[71]),
++	.qe(),
++	.q(reg2hw[222]),
++	.qs(stall_stall11_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin0_buffer0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin0_buffer0_we),
++	.wd(configin0_buffer0_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[56-:5]),
++	.qs(configin0_buffer0_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin0_size0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin0_size0_we),
++	.wd(configin0_size0_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[51-:7]),
++	.qs(configin0_size0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin0_pend0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin0_pend0_we),
++	.wd(configin0_pend0_wd),
++	.de(hw2reg[2]),
++	.d(hw2reg[3]),
++	.qe(),
++	.q(reg2hw[44]),
++	.qs(configin0_pend0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin0_rdy0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin0_rdy0_we),
++	.wd(configin0_rdy0_wd),
++	.de(hw2reg[0]),
++	.d(hw2reg[1]),
++	.qe(),
++	.q(reg2hw[43]),
++	.qs(configin0_rdy0_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin1_buffer1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin1_buffer1_we),
++	.wd(configin1_buffer1_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[70-:5]),
++	.qs(configin1_buffer1_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin1_size1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin1_size1_we),
++	.wd(configin1_size1_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[65-:7]),
++	.qs(configin1_size1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin1_pend1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin1_pend1_we),
++	.wd(configin1_pend1_wd),
++	.de(hw2reg[6]),
++	.d(hw2reg[7]),
++	.qe(),
++	.q(reg2hw[58]),
++	.qs(configin1_pend1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin1_rdy1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin1_rdy1_we),
++	.wd(configin1_rdy1_wd),
++	.de(hw2reg[4]),
++	.d(hw2reg[5]),
++	.qe(),
++	.q(reg2hw[57]),
++	.qs(configin1_rdy1_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin2_buffer2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin2_buffer2_we),
++	.wd(configin2_buffer2_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[84-:5]),
++	.qs(configin2_buffer2_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin2_size2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin2_size2_we),
++	.wd(configin2_size2_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[79-:7]),
++	.qs(configin2_size2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin2_pend2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin2_pend2_we),
++	.wd(configin2_pend2_wd),
++	.de(hw2reg[10]),
++	.d(hw2reg[11]),
++	.qe(),
++	.q(reg2hw[72]),
++	.qs(configin2_pend2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin2_rdy2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin2_rdy2_we),
++	.wd(configin2_rdy2_wd),
++	.de(hw2reg[8]),
++	.d(hw2reg[9]),
++	.qe(),
++	.q(reg2hw[71]),
++	.qs(configin2_rdy2_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin3_buffer3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin3_buffer3_we),
++	.wd(configin3_buffer3_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[98-:5]),
++	.qs(configin3_buffer3_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin3_size3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin3_size3_we),
++	.wd(configin3_size3_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[93-:7]),
++	.qs(configin3_size3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin3_pend3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin3_pend3_we),
++	.wd(configin3_pend3_wd),
++	.de(hw2reg[14]),
++	.d(hw2reg[15]),
++	.qe(),
++	.q(reg2hw[86]),
++	.qs(configin3_pend3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin3_rdy3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin3_rdy3_we),
++	.wd(configin3_rdy3_wd),
++	.de(hw2reg[12]),
++	.d(hw2reg[13]),
++	.qe(),
++	.q(reg2hw[85]),
++	.qs(configin3_rdy3_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin4_buffer4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin4_buffer4_we),
++	.wd(configin4_buffer4_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[112-:5]),
++	.qs(configin4_buffer4_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin4_size4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin4_size4_we),
++	.wd(configin4_size4_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[107-:7]),
++	.qs(configin4_size4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin4_pend4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin4_pend4_we),
++	.wd(configin4_pend4_wd),
++	.de(hw2reg[18]),
++	.d(hw2reg[19]),
++	.qe(),
++	.q(reg2hw[100]),
++	.qs(configin4_pend4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin4_rdy4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin4_rdy4_we),
++	.wd(configin4_rdy4_wd),
++	.de(hw2reg[16]),
++	.d(hw2reg[17]),
++	.qe(),
++	.q(reg2hw[99]),
++	.qs(configin4_rdy4_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin5_buffer5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin5_buffer5_we),
++	.wd(configin5_buffer5_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[126-:5]),
++	.qs(configin5_buffer5_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin5_size5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin5_size5_we),
++	.wd(configin5_size5_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[121-:7]),
++	.qs(configin5_size5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin5_pend5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin5_pend5_we),
++	.wd(configin5_pend5_wd),
++	.de(hw2reg[22]),
++	.d(hw2reg[23]),
++	.qe(),
++	.q(reg2hw[114]),
++	.qs(configin5_pend5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin5_rdy5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin5_rdy5_we),
++	.wd(configin5_rdy5_wd),
++	.de(hw2reg[20]),
++	.d(hw2reg[21]),
++	.qe(),
++	.q(reg2hw[113]),
++	.qs(configin5_rdy5_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin6_buffer6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin6_buffer6_we),
++	.wd(configin6_buffer6_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[140-:5]),
++	.qs(configin6_buffer6_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin6_size6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin6_size6_we),
++	.wd(configin6_size6_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[135-:7]),
++	.qs(configin6_size6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin6_pend6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin6_pend6_we),
++	.wd(configin6_pend6_wd),
++	.de(hw2reg[26]),
++	.d(hw2reg[27]),
++	.qe(),
++	.q(reg2hw[128]),
++	.qs(configin6_pend6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin6_rdy6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin6_rdy6_we),
++	.wd(configin6_rdy6_wd),
++	.de(hw2reg[24]),
++	.d(hw2reg[25]),
++	.qe(),
++	.q(reg2hw[127]),
++	.qs(configin6_rdy6_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin7_buffer7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin7_buffer7_we),
++	.wd(configin7_buffer7_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[154-:5]),
++	.qs(configin7_buffer7_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin7_size7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin7_size7_we),
++	.wd(configin7_size7_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[149-:7]),
++	.qs(configin7_size7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin7_pend7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin7_pend7_we),
++	.wd(configin7_pend7_wd),
++	.de(hw2reg[30]),
++	.d(hw2reg[31]),
++	.qe(),
++	.q(reg2hw[142]),
++	.qs(configin7_pend7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin7_rdy7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin7_rdy7_we),
++	.wd(configin7_rdy7_wd),
++	.de(hw2reg[28]),
++	.d(hw2reg[29]),
++	.qe(),
++	.q(reg2hw[141]),
++	.qs(configin7_rdy7_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin8_buffer8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin8_buffer8_we),
++	.wd(configin8_buffer8_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[168-:5]),
++	.qs(configin8_buffer8_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin8_size8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin8_size8_we),
++	.wd(configin8_size8_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[163-:7]),
++	.qs(configin8_size8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin8_pend8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin8_pend8_we),
++	.wd(configin8_pend8_wd),
++	.de(hw2reg[34]),
++	.d(hw2reg[35]),
++	.qe(),
++	.q(reg2hw[156]),
++	.qs(configin8_pend8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin8_rdy8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin8_rdy8_we),
++	.wd(configin8_rdy8_wd),
++	.de(hw2reg[32]),
++	.d(hw2reg[33]),
++	.qe(),
++	.q(reg2hw[155]),
++	.qs(configin8_rdy8_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin9_buffer9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin9_buffer9_we),
++	.wd(configin9_buffer9_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[182-:5]),
++	.qs(configin9_buffer9_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin9_size9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin9_size9_we),
++	.wd(configin9_size9_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[177-:7]),
++	.qs(configin9_size9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin9_pend9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin9_pend9_we),
++	.wd(configin9_pend9_wd),
++	.de(hw2reg[38]),
++	.d(hw2reg[39]),
++	.qe(),
++	.q(reg2hw[170]),
++	.qs(configin9_pend9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin9_rdy9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin9_rdy9_we),
++	.wd(configin9_rdy9_wd),
++	.de(hw2reg[36]),
++	.d(hw2reg[37]),
++	.qe(),
++	.q(reg2hw[169]),
++	.qs(configin9_rdy9_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin10_buffer10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin10_buffer10_we),
++	.wd(configin10_buffer10_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[196-:5]),
++	.qs(configin10_buffer10_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin10_size10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin10_size10_we),
++	.wd(configin10_size10_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[191-:7]),
++	.qs(configin10_size10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin10_pend10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin10_pend10_we),
++	.wd(configin10_pend10_wd),
++	.de(hw2reg[42]),
++	.d(hw2reg[43]),
++	.qe(),
++	.q(reg2hw[184]),
++	.qs(configin10_pend10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin10_rdy10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin10_rdy10_we),
++	.wd(configin10_rdy10_wd),
++	.de(hw2reg[40]),
++	.d(hw2reg[41]),
++	.qe(),
++	.q(reg2hw[183]),
++	.qs(configin10_rdy10_qs)
++);
++prim_subreg #(
++	.DW(5),
++	.SWACCESS("RW"),
++	.RESVAL(5'h00)
++) u_configin11_buffer11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin11_buffer11_we),
++	.wd(configin11_buffer11_wd),
++	.de(1'b0),
++	.d({5 {1'b0}}),
++	.qe(),
++	.q(reg2hw[210-:5]),
++	.qs(configin11_buffer11_qs)
++);
++prim_subreg #(
++	.DW(7),
++	.SWACCESS("RW"),
++	.RESVAL(7'h00)
++) u_configin11_size11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin11_size11_we),
++	.wd(configin11_size11_wd),
++	.de(1'b0),
++	.d({7 {1'b0}}),
++	.qe(),
++	.q(reg2hw[205-:7]),
++	.qs(configin11_size11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("W1C"),
++	.RESVAL(1'h0)
++) u_configin11_pend11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin11_pend11_we),
++	.wd(configin11_pend11_wd),
++	.de(hw2reg[46]),
++	.d(hw2reg[47]),
++	.qe(),
++	.q(reg2hw[198]),
++	.qs(configin11_pend11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_configin11_rdy11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(configin11_rdy11_we),
++	.wd(configin11_rdy11_wd),
++	.de(hw2reg[44]),
++	.d(hw2reg[45]),
++	.qe(),
++	.q(reg2hw[197]),
++	.qs(configin11_rdy11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso0_we),
++	.wd(iso_iso0_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[31]),
++	.qs(iso_iso0_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso1_we),
++	.wd(iso_iso1_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[32]),
++	.qs(iso_iso1_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso2_we),
++	.wd(iso_iso2_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[33]),
++	.qs(iso_iso2_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso3_we),
++	.wd(iso_iso3_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[34]),
++	.qs(iso_iso3_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso4_we),
++	.wd(iso_iso4_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[35]),
++	.qs(iso_iso4_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso5_we),
++	.wd(iso_iso5_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[36]),
++	.qs(iso_iso5_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso6_we),
++	.wd(iso_iso6_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[37]),
++	.qs(iso_iso6_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso7_we),
++	.wd(iso_iso7_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[38]),
++	.qs(iso_iso7_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso8_we),
++	.wd(iso_iso8_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[39]),
++	.qs(iso_iso8_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso9_we),
++	.wd(iso_iso9_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[40]),
++	.qs(iso_iso9_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso10_we),
++	.wd(iso_iso10_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[41]),
++	.qs(iso_iso10_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_iso_iso11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(iso_iso11_we),
++	.wd(iso_iso11_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[42]),
++	.qs(iso_iso11_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear0(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear0_we),
++	.wd(data_toggle_clear_clear0_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[7]),
++	.q(reg2hw[8]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear1(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear1_we),
++	.wd(data_toggle_clear_clear1_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[9]),
++	.q(reg2hw[10]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear2(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear2_we),
++	.wd(data_toggle_clear_clear2_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[11]),
++	.q(reg2hw[12]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear3(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear3_we),
++	.wd(data_toggle_clear_clear3_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[13]),
++	.q(reg2hw[14]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear4(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear4_we),
++	.wd(data_toggle_clear_clear4_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[15]),
++	.q(reg2hw[16]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear5(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear5_we),
++	.wd(data_toggle_clear_clear5_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[17]),
++	.q(reg2hw[18]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear6(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear6_we),
++	.wd(data_toggle_clear_clear6_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[19]),
++	.q(reg2hw[20]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear7(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear7_we),
++	.wd(data_toggle_clear_clear7_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[21]),
++	.q(reg2hw[22]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear8(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear8_we),
++	.wd(data_toggle_clear_clear8_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[23]),
++	.q(reg2hw[24]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear9(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear9_we),
++	.wd(data_toggle_clear_clear9_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[25]),
++	.q(reg2hw[26]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear10(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear10_we),
++	.wd(data_toggle_clear_clear10_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[27]),
++	.q(reg2hw[28]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("WO"),
++	.RESVAL(1'h0)
++) u_data_toggle_clear_clear11(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(data_toggle_clear_clear11_we),
++	.wd(data_toggle_clear_clear11_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(reg2hw[29]),
++	.q(reg2hw[30]),
++	.qs()
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_phy_config_rx_differential_mode(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_rx_differential_mode_we),
++	.wd(phy_config_rx_differential_mode_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[6]),
++	.qs(phy_config_rx_differential_mode_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_phy_config_tx_differential_mode(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_tx_differential_mode_we),
++	.wd(phy_config_tx_differential_mode_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[5]),
++	.qs(phy_config_tx_differential_mode_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h1)
++) u_phy_config_eop_single_bit(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_eop_single_bit_we),
++	.wd(phy_config_eop_single_bit_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[4]),
++	.qs(phy_config_eop_single_bit_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_phy_config_override_pwr_sense_en(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_override_pwr_sense_en_we),
++	.wd(phy_config_override_pwr_sense_en_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[3]),
++	.qs(phy_config_override_pwr_sense_en_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_phy_config_override_pwr_sense_val(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_override_pwr_sense_val_we),
++	.wd(phy_config_override_pwr_sense_val_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[2]),
++	.qs(phy_config_override_pwr_sense_val_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_phy_config_pinflip(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_pinflip_we),
++	.wd(phy_config_pinflip_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[1]),
++	.qs(phy_config_pinflip_qs)
++);
++prim_subreg #(
++	.DW(1),
++	.SWACCESS("RW"),
++	.RESVAL(1'h0)
++) u_phy_config_usb_ref_disable(
++	.clk_i(clk_i),
++	.rst_ni(rst_ni),
++	.we(phy_config_usb_ref_disable_we),
++	.wd(phy_config_usb_ref_disable_wd),
++	.de(1'b0),
++	.d(1'b0),
++	.qe(),
++	.q(reg2hw[-0]),
++	.qs(phy_config_usb_ref_disable_qs)
++);
+ 
+   logic [25:0] addr_hit;
+   always_comb begin
+-    addr_hit = '0;
++    addr_hit = {26 {1'b0}};
+     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
+     addr_hit[ 1] = (reg_addr == USBDEV_INTR_ENABLE_OFFSET);
+     addr_hit[ 2] = (reg_addr == USBDEV_INTR_TEST_OFFSET);
+@@ -5976,7 +3982,7 @@ module usbdev_reg_top (
+ 
+   // Read data return
+   always_comb begin
+-    reg_rdata_next = '0;
++    reg_rdata_next = {32 {1'b0}};
+     unique case (1'b1)
+       addr_hit[0]: begin
+         reg_rdata_next[0] = intr_state_pkt_received_qs;
+@@ -6052,7 +4058,7 @@ module usbdev_reg_top (
+       end
+ 
+       addr_hit[5]: begin
+-        reg_rdata_next[4:0] = '0;
++        reg_rdata_next[4:0] = {5 {1'b0}};
+       end
+ 
+       addr_hit[6]: begin
+@@ -6247,7 +4253,7 @@ module usbdev_reg_top (
+       end
+ 
+       default: begin
+-        reg_rdata_next = '1;
++        reg_rdata_next = {32 {1'b1}};
+       end
+     endcase
+   end
 diff --git a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
 index bf3bc9fc3..88828411c 100644
 --- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -1733,10 +1733,209 @@ index f25d459ef..c5ea11cb2 100644
      endcase
    end
 diff --git a/hw/ip/usbdev/rtl/usbdev.sv b/hw/ip/usbdev/rtl/usbdev.sv
-index cbdadd624..42a4d1b7a 100644
+index cbdadd624..fc428d9a0 100644
 --- a/hw/ip/usbdev/rtl/usbdev.sv
 +++ b/hw/ip/usbdev/rtl/usbdev.sv
-@@ -563,7 +563,7 @@ module usbdev (
+@@ -90,8 +90,10 @@ module usbdev (
+   // Number of endpoints
+   localparam int NEndpoints = usbdev_reg_pkg::NEndpoints;
+ 
+-  usbdev_reg2hw_t reg2hw;
+-  usbdev_hw2reg_t hw2reg;
++  //usbdev_reg2hw_t reg2hw;
++  //usbdev_hw2reg_t hw2reg;
++  wire [345:0] reg2hw;
++  reg [176:0] hw2reg;
+ 
+   tlul_pkg::tl_h2d_t tl_sram_h2d [1];
+   tlul_pkg::tl_d2h_t tl_sram_d2h [1];
+@@ -165,9 +167,9 @@ module usbdev (
+   logic [AVFifoWidth - 1:0] usb_av_rdata;
+   logic [RXFifoWidth - 1:0] usb_rx_wdata, rx_rdata_raw, rx_rdata;
+ 
+-  assign event_av_overflow = reg2hw.avbuffer.qe & (~av_fifo_wready);
+-  assign hw2reg.usbstat.av_full.d = ~av_fifo_wready;
+-  assign hw2reg.usbstat.rx_empty.d = ~rx_fifo_rvalid;
++  assign event_av_overflow = reg2hw[268] & (~av_fifo_wready);
++  assign hw2reg[117] = ~av_fifo_wready;
++  assign hw2reg[113] = ~rx_fifo_rvalid;
+ 
+   prim_fifo_async #(
+     .Width(AVFifoWidth),
+@@ -176,10 +178,10 @@ module usbdev (
+     .clk_wr_i  (clk_i),
+     .rst_wr_ni (rst_ni),
+ 
+-    .wvalid_i  (reg2hw.avbuffer.qe),
++    .wvalid_i  (reg2hw[268]),
+     .wready_o  (av_fifo_wready),
+-    .wdata_i   (reg2hw.avbuffer.q),
+-    .wdepth_o  (hw2reg.usbstat.av_depth.d),
++    .wdata_i   (reg2hw[273-:5]),
++    .wdepth_o  (hw2reg[120-:3]),
+ 
+     .clk_rd_i  (clk_usb_48mhz_i),
+     .rst_rd_ni (rst_usb_48mhz_ni),
+@@ -189,8 +191,7 @@ module usbdev (
+     .rdepth_o  () // only using empty
+   );
+ 
+-  assign rx_fifo_re = reg2hw.rxfifo.ep.re | reg2hw.rxfifo.setup.re |
+-                      reg2hw.rxfifo.size.re | reg2hw.rxfifo.buffer.re;
++  assign rx_fifo_re = ((reg2hw[247] | reg2hw[252]) | reg2hw[254]) | reg2hw[262];
+ 
+   prim_fifo_async #(
+     .Width(RXFifoWidth),
+@@ -209,21 +210,20 @@ module usbdev (
+     .rvalid_o  (rx_fifo_rvalid),
+     .rready_i  (rx_fifo_re),
+     .rdata_o   (rx_rdata_raw),
+-    .rdepth_o  (hw2reg.usbstat.rx_depth.d)
++    .rdepth_o  (hw2reg[116-:3])
+   );
+ 
+   // Return all zero if the FIFO is empty (instead of X)
+-  assign rx_rdata = rx_fifo_rvalid ? rx_rdata_raw : '0;
+-  assign hw2reg.rxfifo.ep.d = rx_rdata[16:13];
+-  assign hw2reg.rxfifo.setup.d = rx_rdata[12];
+-  assign hw2reg.rxfifo.size.d = rx_rdata[11:5];
+-  assign hw2reg.rxfifo.buffer.d = rx_rdata[4:0];
++  assign rx_rdata = rx_fifo_rvalid ? rx_rdata_raw : {17 {1'b0}};
++  assign hw2reg[99-:4] = rx_rdata[16:13];
++  assign hw2reg[100] = rx_rdata[12];
++  assign hw2reg[107-:7] = rx_rdata[11:5];
++  assign hw2reg[112-:5] = rx_rdata[4:0];
+   assign event_pkt_received = rx_fifo_rvalid;
+ 
+   // The rxfifo register is hrw, but we just need the read enables.
+   logic [16:0] unused_rxfifo_q;
+-  assign unused_rxfifo_q = {reg2hw.rxfifo.ep.q, reg2hw.rxfifo.setup.q,
+-                            reg2hw.rxfifo.size.q, reg2hw.rxfifo.buffer.q};
++  assign unused_rxfifo_q = {reg2hw[251-:4], reg2hw[253], reg2hw[261-:7], reg2hw[267-:5]};
+ 
+   ////////////////////////////////////
+   // IN (Transmit) interface config //
+@@ -245,15 +245,15 @@ module usbdev (
+   // RX enables
+   always_comb begin : proc_map_rxenable
+     for (int i = 0; i < NEndpoints; i++) begin
+-      enable_setup[i] = reg2hw.rxenable_setup[i].q;
+-      enable_out[i]   = reg2hw.rxenable_out[i].q;
++      enable_setup[i] = reg2hw[235 + i];
++      enable_out[i]   = reg2hw[223 + i];
+     end
+   end
+ 
+   // STALL for both directions
+   always_comb begin : proc_map_stall
+     for (int i = 0; i < NEndpoints; i++) begin
+-      ep_stall[i] = reg2hw.stall[i];
++      ep_stall[i] = reg2hw[211 + i+:1];
+     end
+   end
+ 
+@@ -269,21 +269,21 @@ module usbdev (
+   // CDC: ok, quasi-static
+   always_comb begin : proc_map_iso
+     for (int i = 0; i < NEndpoints; i++) begin
+-      ep_iso[i] = reg2hw.iso[i].q;
++      ep_iso[i] = reg2hw[31 + i];
+     end
+   end
+ 
+   // CDC: flop_2sync for ready bit covers others so assigns are ok
+   always_comb begin : proc_map_buf_size
+     for (int i = 0; i < NEndpoints; i++) begin
+-      usb_in_buf[i]  = reg2hw.configin[i].buffer.q;
+-      usb_in_size[i] = reg2hw.configin[i].size.q;
++      usb_in_buf[i]  = reg2hw[43 + ((i * 14) + 13)-:5];
++      usb_in_size[i] = reg2hw[43 + ((i * 14) + 8)-:7];
+     end
+   end
+ 
+   always_comb begin : proc_map_rdy_reg2hw
+     for (int i = 0; i < NEndpoints; i++) begin
+-      in_rdy_async[i] = reg2hw.configin[i].rdy.q;
++      in_rdy_async[i] = reg2hw[43 + (i * 14)];
+     end
+   end
+ 
+@@ -301,7 +301,7 @@ module usbdev (
+   always_comb begin : proc_data_toggle_clear_qe
+     data_toggle_clear_qe = 1'b0;
+     for (int i = 0; i < NEndpoints; i++) begin
+-      data_toggle_clear_qe |= reg2hw.data_toggle_clear[i].qe;
++      data_toggle_clear_qe |= reg2hw[7 + (i * 2)];
+     end
+   end
+ 
+@@ -318,7 +318,7 @@ module usbdev (
+     usb_data_toggle_clear = '0;
+     for (int i = 0; i < NEndpoints; i++) begin
+       if (usb_data_toggle_clear_en) begin
+-        usb_data_toggle_clear[i] = reg2hw.data_toggle_clear[i].q;
++        usb_data_toggle_clear[i] = reg2hw[7 + ((i * 2) + 1)];
+       end
+     end
+   end
+@@ -345,8 +345,8 @@ module usbdev (
+ 
+   always_comb begin : proc_map_sent
+     for (int i = 0; i < NEndpoints; i++) begin
+-      hw2reg.in_sent[i].de = set_sentbit[i];
+-      hw2reg.in_sent[i].d  = 1'b1;
++      hw2reg[72 + (i * 2)] = set_sentbit[i];
++      hw2reg[72 + ((i * 2) + 1)] = 1'b1;
+     end
+   end
+ 
+@@ -441,16 +441,16 @@ module usbdev (
+ 
+   always_comb begin : proc_map_rdy_hw2reg
+     for (int i = 0; i < NEndpoints; i++) begin
+-      hw2reg.configin[i].rdy.de = clear_rdybit[i];
+-      hw2reg.configin[i].rdy.d  = 1'b0;
++      hw2reg[i * 4] = clear_rdybit[i];
++      hw2reg[(i * 4) + 1] = 1'b0;
+     end
+   end
+ 
+   // Update the pending bit by copying the ready bit that is about to clear
+   always_comb begin : proc_map_pend
+     for (int i = 0; i < NEndpoints; i++) begin
+-      hw2reg.configin[i].pend.de = update_pend[i];
+-      hw2reg.configin[i].pend.d  = reg2hw.configin[i].rdy.q | reg2hw.configin[i].pend.q;
++      hw2reg[(i * 4) + 2] = update_pend[i];
++      hw2reg[(i * 4) + 3] = reg2hw[43 + (i * 14)] | reg2hw[43 + ((i * 14) + 1)];
+     end
+   end
+ 
+@@ -516,7 +516,7 @@ module usbdev (
+     .devaddr_i            (usb_device_addr),
+     .clr_devaddr_o        (usb_clr_devaddr),
+     .ep_iso_i             (ep_iso), // cdc ok, quasi-static
+-    .cfg_eop_single_bit_i (reg2hw.phy_config.eop_single_bit.q), // cdc ok: quasi-static
++    .cfg_eop_single_bit_i (reg2hw[4]), // cdc ok: quasi-static
+     .tx_osc_test_mode_i   (1'b0), // cdc ok: quasi-static & testmode only
+     .data_toggle_clear_i  (usb_data_toggle_clear),
+ 
+@@ -548,7 +548,7 @@ module usbdev (
+     .clk_i  (clk_i),
+     .rst_ni (rst_ni),
+     .d_i    ({usb_link_state,              usb_frame}),
+-    .q_o    ({hw2reg.usbstat.link_state.d, hw2reg.usbstat.frame.d})
++    .q_o    ({hw2reg[124-:3], hw2reg[136-:11]})
+   );
+ 
+   // sys clk -> USB clk
+@@ -557,13 +557,13 @@ module usbdev (
+   ) cdc_sys_to_usb (
+     .clk_i  (clk_usb_48mhz_i),
+     .rst_ni (rst_usb_48mhz_ni),
+-    .d_i    ({reg2hw.usbctrl.enable.q, reg2hw.usbctrl.device_address.q}),
++    .d_i    ({reg2hw[281], reg2hw[280-:7]}),
+     .q_o    ({usb_enable,              usb_device_addr})
+   );
  
    // CDC for event signals (arguably they are there for a long time so would be ok)
    // Just want a pulse to ensure only one interrupt for an event
@@ -1745,6 +1944,42 @@ index cbdadd624..42a4d1b7a 100644
      .clk_i  (clk_i),
      .rst_ni (rst_ni),
      .d_i    ({usb_event_disconnect, usb_event_link_reset, usb_event_link_suspend,
+@@ -582,7 +582,7 @@ module usbdev (
+     .dst_pulse_o (event_link_resume)
+   );
+ 
+-  assign hw2reg.usbstat.host_lost.d = event_host_lost;
++  assign hw2reg[125] = event_host_lost;
+ 
+   // resets etc cause the device address to clear
+   prim_pulse_sync usbdev_devclr (
+@@ -591,9 +591,9 @@ module usbdev (
+     .rst_src_ni  (rst_usb_48mhz_ni),
+     .rst_dst_ni  (rst_ni),
+     .src_pulse_i (usb_clr_devaddr),
+-    .dst_pulse_o (hw2reg.usbctrl.device_address.de)
++    .dst_pulse_o (hw2reg[137])
+   );
+-  assign hw2reg.usbctrl.device_address.d = '0;
++  assign hw2reg[144-:7] = {7 {1'b0}};
+ 
+   // AV empty is a single pulse so needs pulsesync
+   prim_pulse_sync sync_usb_event_av_empty (
+@@ -621,11 +621,11 @@ module usbdev (
+   // setup_received, as it is stable
+   always_comb begin : proc_stall_tieoff
+     for (int i = 0; i < NEndpoints; i++) begin
+-      hw2reg.stall[i].d  = 1'b0;
++      hw2reg[48 + ((i * 2) + 1)]  = 1'b0;
+       if (setup_received && usb_out_endpoint_val && usb_out_endpoint == 4'(unsigned'(i))) begin
+-        hw2reg.stall[i].de = 1'b1;
++        hw2reg[48 + (i * 2)] = 1'b1;
+       end else begin
+-        hw2reg.stall[i].de = 1'b0;
++        hw2reg[48 + (i * 2)] = 1'b0;
+       end
+     end
+   end
 @@ -654,8 +654,8 @@ module usbdev (
  
    // SRAM Wrapper
@@ -1756,6 +1991,300 @@ index cbdadd624..42a4d1b7a 100644
      .CfgW  (8),
  
      .EnableECC           (0), // No Protection
+@@ -706,177 +706,177 @@ module usbdev (
+ 
+   prim_intr_hw #(.Width(1)) intr_hw_pkt_received (
+     .event_intr_i           (event_pkt_received),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.pkt_received.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.pkt_received.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.pkt_received.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.pkt_received.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.pkt_received.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.pkt_received.d),
++    .reg2hw_intr_enable_q_i(reg2hw[329]),
++    .reg2hw_intr_test_q_i(reg2hw[313]),
++    .reg2hw_intr_test_qe_i(reg2hw[312]),
++    .reg2hw_intr_state_q_i(reg2hw[345]),
++    .hw2reg_intr_state_de_o (hw2reg[175]),
++    .hw2reg_intr_state_d_o  (hw2reg[176]),
+     .intr_o                 (intr_pkt_received_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_hw_pkt_sent (
+     .event_intr_i           (set_sent),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.pkt_sent.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.pkt_sent.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.pkt_sent.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.pkt_sent.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.pkt_sent.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.pkt_sent.d),
++    .reg2hw_intr_enable_q_i(reg2hw[328]),
++    .reg2hw_intr_test_q_i(reg2hw[311]),
++    .reg2hw_intr_test_qe_i(reg2hw[310]),
++    .reg2hw_intr_state_q_i(reg2hw[344]),
++    .hw2reg_intr_state_de_o (hw2reg[173]),
++    .hw2reg_intr_state_d_o  (hw2reg[174]),
+     .intr_o                 (intr_pkt_sent_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_disconnected (
+     .event_intr_i           (event_disconnect),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.disconnected.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.disconnected.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.disconnected.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.disconnected.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.disconnected.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.disconnected.d),
++    .reg2hw_intr_enable_q_i(reg2hw[327]),
++    .reg2hw_intr_test_q_i(reg2hw[309]),
++    .reg2hw_intr_test_qe_i(reg2hw[308]),
++    .reg2hw_intr_state_q_i(reg2hw[343]),
++    .hw2reg_intr_state_de_o (hw2reg[171]),
++    .hw2reg_intr_state_d_o  (hw2reg[172]),
+     .intr_o                 (intr_disconnected_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_connected (
+     .event_intr_i           (event_connect),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.connected.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.connected.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.connected.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.connected.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.connected.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.connected.d),
++    .reg2hw_intr_enable_q_i(reg2hw[314]),
++    .reg2hw_intr_test_q_i(reg2hw[283]),
++    .reg2hw_intr_test_qe_i(reg2hw[282]),
++    .reg2hw_intr_state_q_i(reg2hw[330]),
++    .hw2reg_intr_state_de_o (hw2reg[145]),
++    .hw2reg_intr_state_d_o  (hw2reg[146]),
+     .intr_o                 (intr_connected_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_host_lost (
+     .event_intr_i           (event_host_lost),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.host_lost.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.host_lost.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.host_lost.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.host_lost.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.host_lost.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.host_lost.d),
++    .reg2hw_intr_enable_q_i(reg2hw[326]),
++    .reg2hw_intr_test_q_i(reg2hw[307]),
++    .reg2hw_intr_test_qe_i(reg2hw[306]),
++    .reg2hw_intr_state_q_i(reg2hw[342]),
++    .hw2reg_intr_state_de_o (hw2reg[169]),
++    .hw2reg_intr_state_d_o  (hw2reg[170]),
+     .intr_o                 (intr_host_lost_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_link_reset (
+     .event_intr_i           (event_link_reset),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_reset.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_reset.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_reset.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_reset.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_reset.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_reset.d),
++    .reg2hw_intr_enable_q_i(reg2hw[325]),
++    .reg2hw_intr_test_q_i(reg2hw[305]),
++    .reg2hw_intr_test_qe_i(reg2hw[304]),
++    .reg2hw_intr_state_q_i(reg2hw[341]),
++    .hw2reg_intr_state_de_o (hw2reg[167]),
++    .hw2reg_intr_state_d_o  (hw2reg[168]),
+     .intr_o                 (intr_link_reset_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_link_suspend (
+     .event_intr_i           (event_link_suspend),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_suspend.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_suspend.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_suspend.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_suspend.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_suspend.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_suspend.d),
++    .reg2hw_intr_enable_q_i(reg2hw[324]),
++    .reg2hw_intr_test_q_i(reg2hw[303]),
++    .reg2hw_intr_test_qe_i(reg2hw[302]),
++    .reg2hw_intr_state_q_i(reg2hw[340]),
++    .hw2reg_intr_state_de_o (hw2reg[165]),
++    .hw2reg_intr_state_d_o  (hw2reg[166]),
+     .intr_o                 (intr_link_suspend_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_link_resume (
+     .event_intr_i           (event_link_resume),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_resume.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_resume.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_resume.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_resume.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_resume.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_resume.d),
++    .reg2hw_intr_enable_q_i(reg2hw[323]),
++    .reg2hw_intr_test_q_i(reg2hw[301]),
++    .reg2hw_intr_test_qe_i(reg2hw[300]),
++    .reg2hw_intr_state_q_i(reg2hw[339]),
++    .hw2reg_intr_state_de_o (hw2reg[163]),
++    .hw2reg_intr_state_d_o  (hw2reg[164]),
+     .intr_o                 (intr_link_resume_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_av_empty (
+     .event_intr_i           (event_av_empty),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.av_empty.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.av_empty.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.av_empty.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.av_empty.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.av_empty.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.av_empty.d),
++    .reg2hw_intr_enable_q_i(reg2hw[322]),
++    .reg2hw_intr_test_q_i(reg2hw[299]),
++    .reg2hw_intr_test_qe_i(reg2hw[298]),
++    .reg2hw_intr_state_q_i(reg2hw[338]),
++    .hw2reg_intr_state_de_o (hw2reg[161]),
++    .hw2reg_intr_state_d_o  (hw2reg[162]),
+     .intr_o                 (intr_av_empty_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_rx_full (
+     .event_intr_i           (event_rx_full),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_full.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_full.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_full.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_full.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_full.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_full.d),
++    .reg2hw_intr_enable_q_i(reg2hw[321]),
++    .reg2hw_intr_test_q_i(reg2hw[297]),
++    .reg2hw_intr_test_qe_i(reg2hw[296]),
++    .reg2hw_intr_state_q_i(reg2hw[337]),
++    .hw2reg_intr_state_de_o (hw2reg[159]),
++    .hw2reg_intr_state_d_o  (hw2reg[160]),
+     .intr_o                 (intr_rx_full_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_av_overflow (
+     .event_intr_i           (event_av_overflow),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.av_overflow.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.av_overflow.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.av_overflow.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.av_overflow.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.av_overflow.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.av_overflow.d),
++    .reg2hw_intr_enable_q_i(reg2hw[320]),
++    .reg2hw_intr_test_q_i(reg2hw[295]),
++    .reg2hw_intr_test_qe_i(reg2hw[294]),
++    .reg2hw_intr_state_q_i(reg2hw[336]),
++    .hw2reg_intr_state_de_o (hw2reg[157]),
++    .hw2reg_intr_state_d_o  (hw2reg[158]),
+     .intr_o                 (intr_av_overflow_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_link_in_err (
+     .event_intr_i           (event_in_err),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_in_err.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_in_err.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_in_err.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_in_err.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_in_err.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_in_err.d),
++    .reg2hw_intr_enable_q_i(reg2hw[319]),
++    .reg2hw_intr_test_q_i(reg2hw[293]),
++    .reg2hw_intr_test_qe_i(reg2hw[292]),
++    .reg2hw_intr_state_q_i(reg2hw[335]),
++    .hw2reg_intr_state_de_o (hw2reg[155]),
++    .hw2reg_intr_state_d_o  (hw2reg[156]),
+     .intr_o                 (intr_link_in_err_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_rx_crc_err (
+     .event_intr_i           (event_rx_crc_err),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_crc_err.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_crc_err.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_crc_err.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_crc_err.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_crc_err.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_crc_err.d),
++    .reg2hw_intr_enable_q_i(reg2hw[318]),
++    .reg2hw_intr_test_q_i(reg2hw[291]),
++    .reg2hw_intr_test_qe_i(reg2hw[290]),
++    .reg2hw_intr_state_q_i(reg2hw[334]),
++    .hw2reg_intr_state_de_o (hw2reg[153]),
++    .hw2reg_intr_state_d_o  (hw2reg[154]),
+     .intr_o                 (intr_rx_crc_err_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_rx_pid_err (
+     .event_intr_i           (event_rx_pid_err),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_pid_err.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_pid_err.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_pid_err.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_pid_err.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_pid_err.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_pid_err.d),
++    .reg2hw_intr_enable_q_i(reg2hw[317]),
++    .reg2hw_intr_test_q_i(reg2hw[289]),
++    .reg2hw_intr_test_qe_i(reg2hw[288]),
++    .reg2hw_intr_state_q_i(reg2hw[333]),
++    .hw2reg_intr_state_de_o (hw2reg[151]),
++    .hw2reg_intr_state_d_o  (hw2reg[152]),
+     .intr_o                 (intr_rx_pid_err_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_rx_bitstuff_err (
+     .event_intr_i           (event_rx_bitstuff_err),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.rx_bitstuff_err.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.rx_bitstuff_err.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.rx_bitstuff_err.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.rx_bitstuff_err.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.rx_bitstuff_err.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.rx_bitstuff_err.d),
++    .reg2hw_intr_enable_q_i(reg2hw[316]),
++    .reg2hw_intr_test_q_i(reg2hw[287]),
++    .reg2hw_intr_test_qe_i(reg2hw[286]),
++    .reg2hw_intr_state_q_i(reg2hw[332]),
++    .hw2reg_intr_state_de_o (hw2reg[149]),
++    .hw2reg_intr_state_d_o  (hw2reg[150]),
+     .intr_o                 (intr_rx_bitstuff_err_o)
+   );
+ 
+   prim_intr_hw #(.Width(1)) intr_frame (
+     .event_intr_i           (event_frame),
+-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.frame.q),
+-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.frame.q),
+-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.frame.qe),
+-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.frame.q),
+-    .hw2reg_intr_state_de_o (hw2reg.intr_state.frame.de),
+-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.frame.d),
++    .reg2hw_intr_enable_q_i(reg2hw[315]),
++    .reg2hw_intr_test_q_i(reg2hw[285]),
++    .reg2hw_intr_test_qe_i(reg2hw[284]),
++    .reg2hw_intr_state_q_i(reg2hw[331]),
++    .hw2reg_intr_state_de_o (hw2reg[147]),
++    .hw2reg_intr_state_d_o  (hw2reg[148]),
+     .intr_o                 (intr_frame_o)
+   );
+ 
+@@ -892,8 +892,8 @@ module usbdev (
+     .rst_usb_48mhz_ni       (rst_usb_48mhz_ni),
+ 
+     // Register interface
+-    .sys_reg2hw_config_i    (reg2hw.phy_config),
+-    .sys_usb_sense_o        (hw2reg.usbstat.sense.d),
++    .sys_reg2hw_config_i    (reg2hw[6-:7]),
++    .sys_usb_sense_o        (hw2reg[121]),
+ 
+     // Chip IO
+     .cio_usb_d_i            (cio_d_i),
+@@ -952,7 +952,7 @@ module usbdev (
+   ) usbdev_sync_phy_config (
+     .clk_i  (clk_usb_48mhz_i),
+     .rst_ni (rst_usb_48mhz_ni),
+-    .d_i    (reg2hw.phy_config.usb_ref_disable.q),
++    .d_i    (reg2hw[-0]),
+     .q_o    (usb_ref_disable)
+   );
+ 
 diff --git a/hw/ip/usbdev/rtl/usbdev_flop_2syncpulse.sv b/hw/ip/usbdev/rtl/usbdev_flop_2syncpulse.sv
 index 9889b0a1f..9b297e67f 100644
 --- a/hw/ip/usbdev/rtl/usbdev_flop_2syncpulse.sv

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -93,7 +93,6 @@ padring.sv \
 padctrl.sv \
 rv_timer_reg_top.sv \
 rv_timer.sv \
-usbdev_reg_top.sv \
 usbdev.sv \
 pwrmgr.sv \
 pwrmgr_cdc.sv \
@@ -313,6 +312,7 @@ prim_filter.sv \
 pinmux_wkup.sv \
 pinmux_reg_top.sv \
 pinmux.sv \
+usbdev_reg_top.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -446,6 +446,7 @@ ${UHDM_file}: ${SV2V_FILE}
 			-top sha2 \
 			-top usbdev_flop_2syncpulse \
 			-top pinmux \
+			-top usbdev_reg_top \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -93,7 +93,6 @@ padring.sv \
 padctrl.sv \
 rv_timer_reg_top.sv \
 rv_timer.sv \
-usbdev.sv \
 pwrmgr.sv \
 pwrmgr_cdc.sv \
 rv_plic_reg_top.sv \
@@ -313,6 +312,7 @@ pinmux_wkup.sv \
 pinmux_reg_top.sv \
 pinmux.sv \
 usbdev_reg_top.sv \
+usbdev.sv \
 
 UHDM_FILES_FULL = \
 	$(shell \
@@ -435,18 +435,15 @@ ${UHDM_file}: ${SV2V_FILE}
 			-top rv_plic_target \
 			-top rv_plic_gateway \
 			-top timer_core \
-			-top usbdev_usbif \
 			-top xbar_main \
 			-top otbn \
 			-top xbar_peri \
-			-top usbdev_iomux \
 			-top gpio_reg_top \
 			-top uart \
 			-top spi_device \
 			-top sha2 \
-			-top usbdev_flop_2syncpulse \
 			-top pinmux \
-			-top usbdev_reg_top \
+			-top usbdev \
 			$(EARLGRAY_INCLUDE) \
 			$(UHDM_FILES_FULL) && \
 	cp ${EARLGRAY_BUILD}/slpp_all/surelog.uhdm ${UHDM_file})
@@ -520,7 +517,6 @@ ${UHDM_file}: ${SV2V_FILE}
 		# -PWidth=32 \
 	# Delete -top otbn when top_earlgrey will be added to uhdm
 	# Delete -top spi_device when top_earlgrey will be added to uhdm
-	# Delete -top usbdev_flop_2syncpulse when usbdev will be added to uhdm
 
 uhdm/yosys/synth-opentitan: ${UHDM_file} ${SV2V_FILE} | ${VENV_OT}
 	(cd ${root_dir}/build && \


### PR DESCRIPTION
``usbdev_reg_top`` and ``usbdev`` uses array inside of packed struct that is currently not supported by yosys, so it was replaced with code generated by sv2v.