### PR TITLE
Remove unused wire in procedural for initialization

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1981,11 +1981,20 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			varbuf->children[0] = buf;
 		}
 
-		if (type == AST_FOR) {
+		if (type == AST_FOR && init_ast->children[0]->id2ast->str.find("$fordecl_block") == std::string::npos) {
 			AstNode *buf = next_ast->clone();
 			delete buf->children[1];
 			buf->children[1] = varbuf->children[0]->clone();
 			current_block->children.insert(current_block->children.begin() + current_block_idx++, buf);
+		} else {
+			// When variable that is used to control a for-loop was declared within the loop,
+			// making it local to the loop scope, we need to remove no longer used wires,
+			// that are already converted to localparams
+			for(auto it = current_ast_mod->children.begin(); it != current_ast_mod->children.end(); it++) {
+				if ((*it) == init_ast->children[0]->id2ast) {
+					current_ast_mod->children.erase(it);
+				}
+			}
 		}
 
 		current_scope[varbuf->str] = backup_scope_varbuf;

--- a/tests/verilog/for_decl_always_comb.ys
+++ b/tests/verilog/for_decl_always_comb.ys
@@ -1,0 +1,18 @@
+read_verilog -sv <<EOT
+module top;
+   logic [9:0] x;
+   logic z;
+   assign z = 1'b1;
+   always_comb begin
+     x = '0; 
+     
+     if (z) begin
+       for (int i = 0 ; i < 10 ; i++) begin
+         x[i] = 1'b1;
+       end
+     end
+   end
+endmodule
+EOT
+hierarchy
+proc


### PR DESCRIPTION
This PR removes procedural ``for`` wire after conversion to localparams.

According to standard (``12.7.1 The for-loop``): 
```
The variables used to control a for-loop can also be declared within the loop, as part of the for_initialization
assignments. This creates an implicit begin-end block around the loop, containing declarations of the loop
variables with automatic lifetime. This block creates a new hierarchical scope, making the variables local to
the loop scope.
```
When we are leaving ``for`` scope the wire that was auto-generated for ``for_initialization`` is no longer needed.
This wire causes problems when ``for_initialization`` is inside ``always_comb`` and ``if`` as it  creates latch.

Example error:
```
ERROR: Latch inferred for signal `\top.$fordecl_block$1.i' from always_comb process `\top.$proc$<<EOT:0$3'.
```