### PR TITLE
Copy only range from typedef in parameters

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1485,8 +1485,10 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			range_left = template_node->range_left;
 			range_right = template_node->range_right;
 			attributes[ID::wiretype] = mkconst_str(resolved_type_node->str);
-			for (auto template_child : template_node->children)
-				children.push_back(template_child->clone());
+			for (auto template_child : template_node->children) {
+				if (template_child->type == AST_RANGE)
+					children.push_back(template_child->clone());
+			}
 			did_something = true;
 		}
 		log_assert(!is_custom_type);

--- a/tests/various/param_struct.ys
+++ b/tests/various/param_struct.ys
@@ -1,0 +1,20 @@
+read_verilog -sv << EOF
+package p;
+typedef struct packed {
+  logic a;
+  logic b;
+} struct_t;
+
+parameter struct_t c = {1'b1, 1'b0};
+endpackage
+
+module dut ();
+parameter p::struct_t d = p::c;
+
+always_comb begin
+  assert(d == 2'b10);
+end
+endmodule
+EOF
+hierarchy; proc; opt
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
This PR fixes the case when parameter is used with a wiretype of a struct.

Currently, all of the wiretype children are copied to the parameter children (this includes e.g. ``AST_STRUCT_ITEM``). This makes ``param_has_no_default`` (https://github.com/YosysHQ/yosys/blob/master/frontends/ast/ast.cc#L981) check fail as it assumes that simplified parameter can only have at most 2 children.

``AST_STRUCT_ITEM`` is unused as children to AST_PARAMETER, so I changed it to only copy AST_RANGE from wiretype node.
