### PR TITLE
Simplify case before trying to detect sign/width

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1389,10 +1389,8 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 
 	if (const_fold && type == AST_CASE)
 	{
-		int width_hint;
-		bool sign_hint;
-		detectSignWidth(width_hint, sign_hint);
 		while (children[0]->simplify(const_fold, at_zero, in_lvalue, stage, width_hint, sign_hint, in_param)) { }
+		detectSignWidth(width_hint, sign_hint);
 		if (children[0]->type == AST_CONSTANT && children[0]->bits_only_01()) {
 			RTLIL::Const case_expr = children[0]->bitsAsConst(width_hint, sign_hint);
 			std::vector<AstNode*> new_children;

--- a/tests/verilog/case_fcall.ys
+++ b/tests/verilog/case_fcall.ys
@@ -1,0 +1,12 @@
+read_verilog -sv << EOF
+module dut();
+logic [5:0] a;
+assign a = '0;
+always_comb begin
+  unique case ($bits(a))
+    6   : a = 6'b111111;
+    default        : a = '0;
+  endcase
+end
+endmodule
+EOF


### PR DESCRIPTION
This PR adds extra simplify before detecting sign/width of the child in case.

This fixes the case where ``case`` uses items that requires simplify before trying to detect sign/width, e.g. ``$bits`` call.