### PR TITLE
Fix ignored `hdlname` attribute in `dfflibmap` pass

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -522,6 +522,7 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module)
 		auto cell_name = cell->name;
 		auto cell_connections = cell->connections();
 		std::string src = cell->get_src_attribute();
+		std::vector<std::string> hdlname = cell->get_hdlname_attribute();
 
 		module->remove(cell);
 
@@ -529,6 +530,7 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module)
 		RTLIL::Cell *new_cell = module->addCell(cell_name, cm.cell_name);
 
 		new_cell->set_src_attribute(src);
+		new_cell->set_hdlname_attribute(hdlname);
 
 		bool has_q = false, has_qn = false;
 		for (auto &port : cm.ports) {

--- a/tests/techmap/dfflibmap_attributes.ys
+++ b/tests/techmap/dfflibmap_attributes.ys
@@ -1,0 +1,19 @@
+read_verilog -icells <<EOT
+
+module top(input C, D, output Q);
+
+$_DFF_N_ ff0 (.C(C), .D(D), .Q(Q));
+
+endmodule
+
+EOT
+
+setattr -set src "top.sv:5" t:$_DFF_N_
+setattr -set hdlname "top.ff0" t:$_DFF_N_
+
+read_liberty -lib dfflibmap.lib
+dfflibmap -liberty dfflibmap.lib
+
+select -assert-count 1 t:dffn
+select -assert-count 1 a:hdlname=top.ff0
+select -assert-count 1 a:src=top.sv:5


### PR DESCRIPTION
This pull request fixes omitted `hdlname` attribute when running `dfflibmap` pass. In current implementation only `src` attribute was moved to new cells from the old ones. I've added a regression test ensuring all desired attributes to be present after the `dfflibmap` pass.